### PR TITLE
Exibe landing page antes do login e ajusta navegação inicial

### DIFF
--- a/components/AplicativoCondominio.tsx
+++ b/components/AplicativoCondominio.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { usarContextoApp } from '../contexts/AppContext';
 import { TelaLogin } from './TelaLogin';
 import { LayoutPrincipal } from './LayoutPrincipal';
@@ -25,6 +25,7 @@ import { PaginaInadimplencia } from './paginas/PaginaInadimplencia';
 import { PaginaAcordos } from './paginas/PaginaAcordos';
 import { PaginaExtratoFinanceiro } from './paginas/PaginaExtratoFinanceiro';
 import { PaginaColaboradores } from './paginas/PaginaColaboradores';
+import { LandingPage, type LandingSection } from './paginas/LandingPage';
 
 // Páginas placeholder para outras funcionalidades
 function PaginaPlaceholder({ titulo }: { titulo: string }) {
@@ -49,6 +50,29 @@ function PaginaPlaceholder({ titulo }: { titulo: string }) {
 export function AplicativoCondominio() {
   const { usuarioLogado, estaCarregando } = usarContextoApp();
   const [paginaAtiva, setPaginaAtiva] = useState('inicio');
+  const [telaPublicaAtiva, setTelaPublicaAtiva] = useState<'landing' | 'login'>('landing');
+  const usuarioAnterior = useRef(usuarioLogado);
+
+  useEffect(() => {
+    if (!usuarioLogado && usuarioAnterior.current) {
+      setTelaPublicaAtiva('landing');
+    }
+
+    usuarioAnterior.current = usuarioLogado;
+  }, [usuarioLogado]);
+
+  const lidarComNavegacaoLanding = (destino: LandingSection) => {
+    if (destino === 'login') {
+      setTelaPublicaAtiva('login');
+      return;
+    }
+
+    const elementoAlvo = document.getElementById(`landing-${destino}`);
+
+    if (elementoAlvo) {
+      elementoAlvo.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  };
 
   if (estaCarregando) {
     return (
@@ -59,7 +83,11 @@ export function AplicativoCondominio() {
   }
 
   if (!usuarioLogado) {
-    return <TelaLogin />;
+    if (telaPublicaAtiva === 'login') {
+      return <TelaLogin onVoltarInicio={() => setTelaPublicaAtiva('landing')} />;
+    }
+
+    return <LandingPage onNavigate={lidarComNavegacaoLanding} />;
   }
 
   const renderizarPagina = () => {

--- a/components/TelaLogin.tsx
+++ b/components/TelaLogin.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Building2, Mail, Lock, Eye, EyeOff } from 'lucide-react';
+import { Building2, Mail, Lock, Eye, EyeOff, ArrowLeft } from 'lucide-react';
 import { Button } from './ui/button';
 import { Input } from './ui/input';
 import { Label } from './ui/label';
@@ -9,7 +9,11 @@ import { Separator } from './ui/separator';
 import { ToggleTema } from './ToggleTema';
 import { usarContextoApp } from '../contexts/AppContext';
 
-export function TelaLogin() {
+interface TelaLoginProps {
+  onVoltarInicio?: () => void;
+}
+
+export function TelaLogin({ onVoltarInicio }: TelaLoginProps) {
   const { fazerLogin } = usarContextoApp();
   const [email, setEmail] = useState('');
   const [senha, setSenha] = useState('');
@@ -46,6 +50,19 @@ export function TelaLogin() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-background to-accent/20 flex items-center justify-center p-4">
+      {onVoltarInicio && (
+        <div className="absolute top-4 left-4">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="gap-2 text-muted-foreground hover:text-foreground"
+            onClick={onVoltarInicio}
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Voltar
+          </Button>
+        </div>
+      )}
       {/* Toggle tema no canto superior direito */}
       <div className="absolute top-4 right-4">
         <ToggleTema />

--- a/components/paginas/LandingPage.tsx
+++ b/components/paginas/LandingPage.tsx
@@ -97,7 +97,10 @@ const noticeHighlights = [
 export function LandingPage({ onNavigate }: LandingPageProps) {
   return (
     <div className="min-h-screen bg-gradient-to-b from-background via-background/95 to-background text-foreground">
-      <header className="relative overflow-hidden border-b border-border/60 bg-gradient-to-br from-primary/10 via-background to-background">
+      <header
+        id="landing-login"
+        className="relative overflow-hidden border-b border-border/60 bg-gradient-to-br from-primary/10 via-background to-background"
+      >
         {/* Hero com foco em confiança e inovação, reforçando o posicionamento premium do produto */}
         <div className="mx-auto flex max-w-6xl flex-col gap-10 px-6 py-16 md:flex-row md:items-center md:justify-between">
           <div className="max-w-2xl space-y-6">
@@ -197,7 +200,7 @@ export function LandingPage({ onNavigate }: LandingPageProps) {
           </div>
         </section>
 
-        <section aria-labelledby="avisos" className="grid gap-10 lg:grid-cols-[3fr_2fr]">
+        <section id="landing-avisos" aria-labelledby="avisos" className="grid gap-10 lg:grid-cols-[3fr_2fr]">
           <div className="space-y-6">
             <div className="flex items-center justify-between flex-wrap gap-3">
               <div>
@@ -316,6 +319,7 @@ interface ShortcutCardProps {
 const ShortcutCard: FC<ShortcutCardProps> = ({ item, onNavigate }) => {
   return (
     <button
+      id={`landing-${item.id}`}
       type="button"
       onClick={() => onNavigate?.(item.id)}
       className="group relative flex h-full flex-col gap-4 rounded-3xl border border-border/70 bg-card/80 p-6 text-left shadow-sm transition-transform hover:-translate-y-1 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/70 focus-visible:ring-offset-2"


### PR DESCRIPTION
## Summary
- exibe a landing page quando não há usuário autenticado e controla a navegação pública
- adiciona atalho de retorno à tela inicial no formulário de login
- inclui âncoras na landing page para permitir rolagem suave para as seções destacadas

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d46e9431408333b38801b5878c0ef6