### PR TITLE
Reset file input after importing plano de contas

### DIFF
--- a/components/paginas/PaginaPlanoContas.tsx
+++ b/components/paginas/PaginaPlanoContas.tsx
@@ -20,7 +20,8 @@ export function PaginaPlanoContas() {
   };
 
   const handleImportar = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const arquivo = e.target.files?.[0];
+    const input = e.target;
+    const arquivo = input.files?.[0];
     if (!arquivo) return;
     const reader = new FileReader();
     reader.onload = (ev) => {
@@ -29,7 +30,12 @@ export function PaginaPlanoContas() {
         importarCategorias(dados);
       } catch {
         // Ignorar erros de importação
+      } finally {
+        input.value = '';
       }
+    };
+    reader.onerror = () => {
+      input.value = '';
     };
     reader.readAsText(arquivo);
   };


### PR DESCRIPTION
## Summary
- store the file input reference in `handleImportar`
- clear the file input value after processing the uploaded JSON
- ensure the input resets even when parsing fails

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d992583b48833395a8a04abc2e7cb8