### PR TITLE
Remove consumo option from síndico area

### DIFF
--- a/components/AplicativoCondominio.tsx
+++ b/components/AplicativoCondominio.tsx
@@ -52,6 +52,7 @@ export function AplicativoCondominio() {
   const [paginaAtiva, setPaginaAtiva] = useState('inicio');
   const [telaPublicaAtiva, setTelaPublicaAtiva] = useState<'landing' | 'login'>('landing');
   const usuarioAnterior = useRef(usuarioLogado);
+  const ehSindico = usuarioLogado?.tipo === 'sindico';
 
   useEffect(() => {
     if (!usuarioLogado && usuarioAnterior.current) {
@@ -60,6 +61,12 @@ export function AplicativoCondominio() {
 
     usuarioAnterior.current = usuarioLogado;
   }, [usuarioLogado]);
+
+  useEffect(() => {
+    if (ehSindico && paginaAtiva === 'consumo') {
+      setPaginaAtiva('inicio');
+    }
+  }, [ehSindico, paginaAtiva]);
 
   const lidarComNavegacaoLanding = (destino: LandingSection) => {
     if (destino === 'login') {
@@ -101,7 +108,7 @@ export function AplicativoCondominio() {
       case 'boletos':
         return <PaginaBoletos />;
       case 'consumo':
-        return <PaginaConsumo />;
+        return ehSindico ? <PaginaInicio onMudarPagina={setPaginaAtiva} /> : <PaginaConsumo />;
       case 'ocorrencias':
         return <PaginaOcorrencias />;
       case 'chat':

--- a/components/LayoutPrincipal.tsx
+++ b/components/LayoutPrincipal.tsx
@@ -68,7 +68,6 @@ export function LayoutPrincipal({ children, paginaAtiva, onMudarPagina }: Layout
     { id: 'planoContas', label: 'Plano de Contas', icone: FileSpreadsheet },
     { id: 'importarLancamentos', label: 'Importar Lançamentos', icone: Upload },
     { id: 'extrato', label: 'Extrato', icone: ReceiptText },
-    { id: 'consumo', label: 'Consumo', icone: Gauge },
     { id: 'inadimplencia', label: 'Inadimplência', icone: FileWarning },
     { id: 'acordos', label: 'Acordos', icone: HandCoins },
     { id: 'avaliacao', label: 'Avaliações', icone: Star },


### PR DESCRIPTION
## Summary
- remove the consumo item from the síndico navigation menu so it no longer appears in the sidebar
- redirect síndico users away from the consumo route to the dashboard to prevent accessing the page directly

