### PR TITLE
refactor: refresh home marketing layout

### DIFF
--- a/public/assets/marketing/hero.svg
+++ b/public/assets/marketing/hero.svg
@@ -1,0 +1,75 @@
+<svg width="960" height="800" viewBox="0 0 960 800" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="heroTitle heroDesc">
+  <title id="heroTitle">Aplicativo MeuCondomínio com dashboards e marketplace</title>
+  <desc id="heroDesc">Mockup realista inspirado no pacote Marketing Screens com telas móveis exibindo métricas financeiras e marketplace.</desc>
+  <defs>
+    <linearGradient id="hero-surface" x1="120" y1="60" x2="840" y2="720" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#111C3B"/>
+      <stop offset="0.45" stop-color="#0F172A"/>
+      <stop offset="1" stop-color="#020617"/>
+    </linearGradient>
+    <radialGradient id="hero-glow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(680 160) rotate(135) scale(420 360)">
+      <stop offset="0" stop-color="#38BDF8" stop-opacity="0.65"/>
+      <stop offset="1" stop-color="#020617" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="hero-glow-2" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(280 620) rotate(35) scale(360 320)">
+      <stop offset="0" stop-color="#22C55E" stop-opacity="0.55"/>
+      <stop offset="1" stop-color="#020617" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="hero-shadow" x="-60" y="-60" width="1080" height="920" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="45" stdDeviation="45" flood-color="#020617" flood-opacity="0.55"/>
+    </filter>
+    <linearGradient id="hero-card" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#111C3B"/>
+      <stop offset="1" stop-color="#1E3A8A"/>
+    </linearGradient>
+    <linearGradient id="hero-pill" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#22C55E"/>
+      <stop offset="1" stop-color="#38BDF8"/>
+    </linearGradient>
+    <linearGradient id="hero-badge" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#F8FAFC" stop-opacity="0.75"/>
+      <stop offset="1" stop-color="#E0F2FE" stop-opacity="0.45"/>
+    </linearGradient>
+  </defs>
+  <rect x="60" y="40" width="840" height="720" rx="64" fill="url(#hero-surface)"/>
+  <ellipse cx="690" cy="170" rx="340" ry="240" fill="url(#hero-glow)"/>
+  <ellipse cx="300" cy="600" rx="320" ry="220" fill="url(#hero-glow-2)"/>
+  <g filter="url(#hero-shadow)">
+    <rect x="280" y="120" width="240" height="520" rx="48" fill="#050C26" stroke="#1E293B" stroke-width="2"/>
+    <rect x="300" y="170" width="200" height="420" rx="32" fill="#0F172A"/>
+    <rect x="312" y="186" width="176" height="42" rx="12" fill="#111C3B" stroke="#1E293B" stroke-width="1"/>
+    <rect x="328" y="200" width="88" height="16" rx="8" fill="#22D3EE"/>
+    <rect x="328" y="232" width="124" height="12" rx="6" fill="#38BDF8" opacity="0.8"/>
+    <rect x="312" y="248" width="176" height="118" rx="20" fill="#020617" stroke="#1E293B" stroke-opacity="0.7"/>
+    <rect x="328" y="268" width="144" height="16" rx="8" fill="#22C55E"/>
+    <rect x="328" y="296" width="120" height="12" rx="6" fill="#38BDF8" opacity="0.6"/>
+    <rect x="312" y="378" width="176" height="104" rx="20" fill="#050C26" stroke="#1E293B" stroke-opacity="0.6"/>
+    <rect x="332" y="400" width="136" height="14" rx="7" fill="#A855F7" opacity="0.9"/>
+    <rect x="332" y="426" width="120" height="10" rx="5" fill="#38BDF8" opacity="0.7"/>
+    <rect x="312" y="500" width="176" height="60" rx="18" fill="#0EA5E9" opacity="0.25"/>
+  </g>
+  <g filter="url(#hero-shadow)">
+    <rect x="480" y="220" width="320" height="260" rx="40" fill="url(#hero-card)" stroke="#334155" stroke-width="1.5"/>
+    <rect x="512" y="256" width="256" height="36" rx="18" fill="#0B1120" stroke="#1E293B" stroke-width="1"/>
+    <rect x="528" y="268" width="120" height="12" rx="6" fill="#22C55E"/>
+    <rect x="512" y="312" width="256" height="120" rx="24" fill="#050C26" stroke="#1E293B" stroke-opacity="0.6"/>
+    <rect x="532" y="332" width="104" height="64" rx="18" fill="#0EA5E9" opacity="0.35"/>
+    <rect x="644" y="332" width="92" height="20" rx="10" fill="#22C55E" opacity="0.75"/>
+    <rect x="644" y="364" width="132" height="16" rx="8" fill="#38BDF8" opacity="0.65"/>
+    <rect x="512" y="448" width="150" height="24" rx="12" fill="#22D3EE"/>
+    <rect x="668" y="448" width="100" height="24" rx="12" fill="#34D399"/>
+  </g>
+  <g filter="url(#hero-shadow)">
+    <rect x="560" y="520" width="260" height="92" rx="36" fill="url(#hero-pill)"/>
+    <rect x="592" y="540" width="52" height="52" rx="26" fill="#020617" opacity="0.75"/>
+    <rect x="656" y="548" width="128" height="20" rx="10" fill="#F8FAFC" opacity="0.92"/>
+    <rect x="656" y="574" width="96" height="12" rx="6" fill="#E2E8F0" opacity="0.7"/>
+  </g>
+  <g opacity="0.75">
+    <rect x="140" y="210" width="180" height="140" rx="32" fill="#1E3A8A" opacity="0.3"/>
+    <rect x="160" y="238" width="84" height="16" rx="8" fill="#E0F2FE" opacity="0.8"/>
+    <rect x="160" y="268" width="120" height="14" rx="7" fill="#34D399" opacity="0.65"/>
+    <rect x="120" y="520" width="220" height="130" rx="36" fill="#22D3EE" opacity="0.25"/>
+    <rect x="150" y="560" width="120" height="16" rx="8" fill="#F8FAFC" opacity="0.6"/>
+  </g>
+</svg>

--- a/public/assets/marketing/market-illus.svg
+++ b/public/assets/marketing/market-illus.svg
@@ -1,0 +1,61 @@
+<svg width="880" height="640" viewBox="0 0 880 640" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="marketTitle marketDesc">
+  <title id="marketTitle">Marketplace MeuCondomínio</title>
+  <desc id="marketDesc">Mosaico com cards inspirados no Marketing Screens exibindo avaliações, filtros e listagens.</desc>
+  <defs>
+    <linearGradient id="market-bg" x1="80" y1="40" x2="760" y2="600" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0B1120"/>
+      <stop offset="1" stop-color="#020617"/>
+    </linearGradient>
+    <filter id="market-shadow" x="-60" y="-60" width="1000" height="760" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="40" stdDeviation="45" flood-color="#01050f" flood-opacity="0.55"/>
+    </filter>
+    <linearGradient id="market-pill" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#22C55E"/>
+      <stop offset="1" stop-color="#0EA5E9"/>
+    </linearGradient>
+  </defs>
+  <rect x="60" y="40" width="760" height="560" rx="56" fill="url(#market-bg)"/>
+  <g filter="url(#market-shadow)">
+    <rect x="160" y="120" width="240" height="360" rx="32" fill="#0F172A" stroke="#1E293B" stroke-width="1.5"/>
+    <rect x="180" y="148" width="200" height="44" rx="16" fill="#0B1120" stroke="#1E293B" stroke-width="1"/>
+    <rect x="200" y="162" width="120" height="16" rx="8" fill="#22C55E"/>
+    <rect x="180" y="210" width="200" height="90" rx="24" fill="#020617" stroke="#1E293B" stroke-opacity="0.6"/>
+    <rect x="200" y="234" width="76" height="52" rx="16" fill="#38BDF8" opacity="0.35"/>
+    <rect x="288" y="228" width="80" height="14" rx="7" fill="#E0F2FE" opacity="0.85"/>
+    <rect x="288" y="252" width="96" height="12" rx="6" fill="#22D3EE" opacity="0.7"/>
+    <rect x="180" y="314" width="200" height="90" rx="24" fill="#020617" stroke="#1E293B" stroke-opacity="0.6"/>
+    <rect x="200" y="338" width="76" height="52" rx="16" fill="#34D399" opacity="0.35"/>
+    <rect x="288" y="332" width="84" height="14" rx="7" fill="#E0F2FE" opacity="0.85"/>
+    <rect x="288" y="356" width="96" height="12" rx="6" fill="#5EEAD4" opacity="0.7"/>
+    <rect x="180" y="418" width="200" height="48" rx="18" fill="#0EA5E9" opacity="0.2"/>
+    <rect x="220" y="430" width="120" height="16" rx="8" fill="#F8FAFC" opacity="0.75"/>
+  </g>
+  <g filter="url(#market-shadow)">
+    <rect x="392" y="96" width="328" height="176" rx="28" fill="#0F172A" stroke="#1E293B" stroke-width="1.5"/>
+    <rect x="424" y="124" width="96" height="32" rx="16" fill="#0B1120" stroke="#1E293B" stroke-width="1"/>
+    <rect x="436" y="136" width="72" height="12" rx="6" fill="#22C55E"/>
+    <rect x="536" y="124" width="160" height="32" rx="16" fill="#0B1120" stroke="#1E293B" stroke-width="1"/>
+    <rect x="548" y="136" width="136" height="12" rx="6" fill="#38BDF8"/>
+    <rect x="424" y="172" width="264" height="80" rx="24" fill="#020617" stroke="#1E293B" stroke-opacity="0.6"/>
+    <rect x="448" y="194" width="84" height="36" rx="14" fill="#22D3EE" opacity="0.35"/>
+    <rect x="548" y="186" width="88" height="14" rx="7" fill="#F1F5F9" opacity="0.85"/>
+    <rect x="548" y="210" width="120" height="12" rx="6" fill="#22C55E" opacity="0.75"/>
+  </g>
+  <g filter="url(#market-shadow)">
+    <rect x="360" y="320" width="344" height="208" rx="32" fill="#050C26" stroke="#1E293B" stroke-width="1.5"/>
+    <rect x="392" y="348" width="280" height="36" rx="18" fill="#0B1120" stroke="#1E293B" stroke-width="1"/>
+    <rect x="408" y="360" width="120" height="12" rx="6" fill="#22C55E"/>
+    <rect x="392" y="396" width="140" height="28" rx="14" fill="#020617" stroke="#1E293B" stroke-opacity="0.5"/>
+    <rect x="548" y="396" width="108" height="28" rx="14" fill="#020617" stroke="#1E293B" stroke-opacity="0.5"/>
+    <rect x="412" y="404" width="100" height="12" rx="6" fill="#38BDF8" opacity="0.65"/>
+    <rect x="568" y="404" width="80" height="12" rx="6" fill="#5EEAD4" opacity="0.65"/>
+    <rect x="392" y="440" width="280" height="72" rx="24" fill="#020617" stroke="#1E293B" stroke-opacity="0.55"/>
+    <rect x="416" y="460" width="96" height="36" rx="14" fill="#22D3EE" opacity="0.35"/>
+    <rect x="520" y="456" width="120" height="16" rx="8" fill="#F8FAFC" opacity="0.85"/>
+    <rect x="520" y="482" width="96" height="12" rx="6" fill="#E2E8F0" opacity="0.7"/>
+  </g>
+  <g>
+    <rect x="248" y="504" width="136" height="48" rx="24" fill="url(#market-pill)"/>
+    <rect x="272" y="520" width="88" height="16" rx="8" fill="#020617" opacity="0.8"/>
+  </g>
+</svg>

--- a/public/assets/marketing/mock-1.svg
+++ b/public/assets/marketing/mock-1.svg
@@ -1,0 +1,29 @@
+<svg width="320" height="220" viewBox="0 0 320 220" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="mock1Title mock1Desc">
+  <title id="mock1Title">Resumo financeiro</title>
+  <desc id="mock1Desc">Cartão com métricas de inadimplência, gráficos e botões inspirado no Marketing Screens.</desc>
+  <defs>
+    <linearGradient id="mock1-surface" x1="40" y1="20" x2="280" y2="200" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0F172A"/>
+      <stop offset="1" stop-color="#1E3A8A"/>
+    </linearGradient>
+    <filter id="mock1-shadow" x="-40" y="-40" width="400" height="300" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="18" stdDeviation="22" flood-color="#020617" flood-opacity="0.45"/>
+    </filter>
+    <linearGradient id="mock1-accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#22C55E"/>
+      <stop offset="1" stop-color="#38BDF8"/>
+    </linearGradient>
+  </defs>
+  <g filter="url(#mock1-shadow)">
+    <rect x="32" y="24" width="256" height="172" rx="28" fill="url(#mock1-surface)" stroke="#1E293B" stroke-opacity="0.6"/>
+    <rect x="60" y="56" width="72" height="72" rx="20" fill="#0EA5E9" opacity="0.3"/>
+    <rect x="72" y="68" width="48" height="48" rx="14" fill="#38BDF8" opacity="0.8"/>
+    <rect x="140" y="56" width="120" height="16" rx="8" fill="#E0F2FE" opacity="0.85"/>
+    <rect x="140" y="80" width="96" height="12" rx="6" fill="#5EEAD4" opacity="0.75"/>
+    <rect x="140" y="100" width="88" height="12" rx="6" fill="#34D399" opacity="0.8"/>
+    <rect x="60" y="140" width="160" height="36" rx="18" fill="#020617" opacity="0.35" stroke="#1E293B" stroke-opacity="0.5"/>
+    <rect x="80" y="150" width="120" height="16" rx="8" fill="#22C55E" opacity="0.85"/>
+    <rect x="206" y="140" width="60" height="36" rx="18" fill="url(#mock1-accent)"/>
+    <rect x="218" y="152" width="36" height="12" rx="6" fill="#020617" opacity="0.8"/>
+  </g>
+</svg>

--- a/public/assets/marketing/mock-2.svg
+++ b/public/assets/marketing/mock-2.svg
@@ -1,0 +1,29 @@
+<svg width="320" height="220" viewBox="0 0 320 220" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="mock2Title mock2Desc">
+  <title id="mock2Title">Experiência dos moradores</title>
+  <desc id="mock2Desc">Tela simulada de app com feed de avisos e marketplace interno.</desc>
+  <defs>
+    <linearGradient id="mock2-surface" x1="20" y1="16" x2="300" y2="204" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#020617"/>
+      <stop offset="1" stop-color="#111C3B"/>
+    </linearGradient>
+    <filter id="mock2-shadow" x="-40" y="-40" width="400" height="300" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="18" stdDeviation="22" flood-color="#020617" flood-opacity="0.45"/>
+    </filter>
+    <linearGradient id="mock2-pill" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#A855F7"/>
+      <stop offset="1" stop-color="#38BDF8"/>
+    </linearGradient>
+  </defs>
+  <g filter="url(#mock2-shadow)">
+    <rect x="24" y="20" width="272" height="176" rx="28" fill="url(#mock2-surface)" stroke="#1E293B" stroke-opacity="0.6"/>
+    <rect x="52" y="52" width="96" height="28" rx="14" fill="#0B1120" stroke="#1E293B" stroke-opacity="0.6"/>
+    <rect x="68" y="62" width="64" height="12" rx="6" fill="#F8FAFC" opacity="0.85"/>
+    <rect x="52" y="92" width="216" height="36" rx="18" fill="#050C26" stroke="#1E293B" stroke-opacity="0.5"/>
+    <rect x="68" y="102" width="88" height="12" rx="6" fill="#22C55E" opacity="0.85"/>
+    <rect x="168" y="102" width="80" height="12" rx="6" fill="#38BDF8" opacity="0.7"/>
+    <rect x="52" y="140" width="216" height="48" rx="18" fill="#020617" stroke="#1E293B" stroke-opacity="0.5"/>
+    <rect x="68" y="150" width="60" height="12" rx="6" fill="#F1F5F9" opacity="0.8"/>
+    <rect x="136" y="150" width="88" height="12" rx="6" fill="#5EEAD4" opacity="0.75"/>
+    <rect x="224" y="148" width="32" height="32" rx="10" fill="url(#mock2-pill)"/>
+  </g>
+</svg>

--- a/public/assets/marketing/mock-3.svg
+++ b/public/assets/marketing/mock-3.svg
@@ -1,0 +1,24 @@
+<svg width="320" height="220" viewBox="0 0 320 220" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="mock3Title mock3Desc">
+  <title id="mock3Title">Superpoderes do síndico</title>
+  <desc id="mock3Desc">Dashboard com indicadores de inadimplência, tarefas e alertas automáticos.</desc>
+  <defs>
+    <linearGradient id="mock3-surface" x1="36" y1="24" x2="284" y2="196" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#111C3B"/>
+      <stop offset="1" stop-color="#1F2937"/>
+    </linearGradient>
+    <filter id="mock3-shadow" x="-40" y="-40" width="400" height="300" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="18" stdDeviation="22" flood-color="#020617" flood-opacity="0.45"/>
+    </filter>
+  </defs>
+  <g filter="url(#mock3-shadow)">
+    <rect x="28" y="24" width="264" height="172" rx="28" fill="url(#mock3-surface)" stroke="#1E293B" stroke-opacity="0.6"/>
+    <rect x="56" y="56" width="208" height="32" rx="16" fill="#0B1120" stroke="#1E293B" stroke-opacity="0.5"/>
+    <rect x="72" y="68" width="120" height="12" rx="6" fill="#F8FAFC" opacity="0.85"/>
+    <rect x="56" y="102" width="208" height="32" rx="16" fill="#020617" stroke="#1E293B" stroke-opacity="0.5"/>
+    <rect x="72" y="112" width="92" height="12" rx="6" fill="#38BDF8" opacity="0.75"/>
+    <rect x="56" y="140" width="100" height="40" rx="16" fill="#0EA5E9" opacity="0.3"/>
+    <rect x="80" y="152" width="56" height="12" rx="6" fill="#22C55E" opacity="0.85"/>
+    <rect x="168" y="140" width="96" height="40" rx="16" fill="#020617" stroke="#1E293B" stroke-opacity="0.5"/>
+    <rect x="184" y="152" width="64" height="12" rx="6" fill="#5EEAD4" opacity="0.7"/>
+  </g>
+</svg>

--- a/src/components/home/ThemeToggle.tsx
+++ b/src/components/home/ThemeToggle.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useTheme } from 'next-themes';
+import { MoonStar, Sun } from 'lucide-react';
+import clsx from 'clsx';
+
+interface ThemeToggleProps {
+  className?: string;
+}
+
+export function ThemeToggle({ className }: ThemeToggleProps) {
+  const { resolvedTheme, theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const effectiveTheme = useMemo(() => {
+    if (theme === 'system') {
+      return resolvedTheme ?? 'light';
+    }
+
+    return theme ?? 'light';
+  }, [resolvedTheme, theme]);
+
+  const isDark = effectiveTheme === 'dark';
+
+  const handleToggle = () => {
+    setTheme(isDark ? 'light' : 'dark');
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleToggle}
+      className={clsx('home-theme-toggle', className)}
+      aria-label={isDark ? 'Ativar tema claro' : 'Ativar tema escuro'}
+      aria-pressed={isDark}
+    >
+      <span className="home-theme-toggle__icon" aria-hidden="true">
+        {mounted ? (
+          isDark ? <Sun strokeWidth={1.75} /> : <MoonStar strokeWidth={1.75} />
+        ) : (
+          <MoonStar strokeWidth={1.75} />
+        )}
+      </span>
+      <span className="home-theme-toggle__label">
+        {mounted ? (isDark ? 'Modo claro' : 'Modo escuro') : 'Alternar tema'}
+      </span>
+    </button>
+  );
+}
+
+export default ThemeToggle;

--- a/src/pages/HomeNew.tsx
+++ b/src/pages/HomeNew.tsx
@@ -1,0 +1,964 @@
+import { useEffect } from 'react';
+import {
+  ArrowRight,
+  BarChart3,
+  Building2,
+  CheckCircle2,
+  MessageSquare,
+  ShieldCheck,
+  Sparkles,
+  Star,
+} from 'lucide-react';
+import ThemeToggle from '../components/home/ThemeToggle';
+import type { MarketingPageProps, MarketingPath } from '../../components/marketing/MarketingLayout';
+
+const NAVIGATION_LINKS: Array<{ href: MarketingPath; label: string }> = [
+  { href: '/solucoes', label: 'Soluções' },
+  { href: '/precos', label: 'Preços' },
+  { href: '/sobre', label: 'Sobre' },
+  { href: '/suporte', label: 'Suporte' },
+  { href: '/blog', label: 'Blog' },
+];
+
+const HERO_FEATURES = [
+  {
+    title: 'Financeiro turbo',
+    description:
+      'Boletos com registro automático, conciliação em tempo real e projeção de fluxo de caixa para decisões sem sustos.',
+    icon: BarChart3,
+  },
+  {
+    title: 'Comunicação inteligente',
+    description:
+      'Envie comunicados segmentados, automatize avisos e acompanhe a leitura em tempo real com recibos digitais.',
+    icon: MessageSquare,
+  },
+  {
+    title: 'Operações conectadas',
+    description:
+      'Reservas, ocorrências, assembleias digitais e marketplace funcionando de ponta a ponta em uma só plataforma.',
+    icon: Building2,
+  },
+];
+
+const MARKETPLACE_PILLS = [
+  'Classificados com aprovação em 1 clique',
+  'Pagamentos via PIX e cartão',
+  'Histórico de reputação e avaliações',
+  'Cupons para fornecedores parceiros',
+];
+
+const MODULES = [
+  {
+    title: 'Gestão financeira completa',
+    points: [
+      'Fluxo de caixa unificado',
+      'Prestação de contas com um clique',
+      'Integração bancária automática',
+    ],
+    media: {
+      src: '/assets/marketing/mock-1.svg',
+      width: 420,
+      height: 300,
+    },
+  },
+  {
+    title: 'Experiência premium para moradores',
+    points: [
+      'Aplicativo com marca do condomínio',
+      'Atendimento 24/7 com assistente virtual',
+      'Marketplace interno para serviços e produtos',
+    ],
+    media: {
+      src: '/assets/marketing/mock-2.svg',
+      width: 420,
+      height: 300,
+    },
+  },
+  {
+    title: 'Superpoderes para o síndico',
+    points: [
+      'Dashboards com indicadores de inadimplência',
+      'Workflows automatizados para tarefas recorrentes',
+      'Biblioteca de documentos sempre atualizada',
+    ],
+    media: {
+      src: '/assets/marketing/mock-3.svg',
+      width: 420,
+      height: 300,
+    },
+  },
+];
+
+const METRICS = [
+  { value: '92%', label: 'redução no tempo de fechamento mensal' },
+  { value: '3x', label: 'mais engajamento dos moradores no app' },
+  { value: '48h', label: 'para colocar o condomínio em produção' },
+  { value: '∞', label: 'integrações com bancos e fabricantes de IoT' },
+];
+
+const TESTIMONIALS = [
+  {
+    quote:
+      '“Migramos 12 condomínios em menos de uma semana. O MeuCondomínio trouxe transparência para o conselho e reduziu em 63% as visitas presenciais ao escritório.”',
+    author: 'Marina Lopes — Gestora na Vizinhança Administradora',
+  },
+  {
+    quote:
+      '“O marketplace interno virou uma fonte de renda para os moradores. Já foram mais de 800 serviços contratados sem sair do aplicativo.”',
+    author: 'André Cavalcanti — Síndico profissional',
+  },
+];
+
+export default function HomeNew({ onLogin, onNavigate }: MarketingPageProps) {
+  useEffect(() => {
+    document.title = 'MeuCondomínio — Gestão completa para condomínios';
+  }, []);
+
+  return (
+    <div className="home-new">
+      <style>{`
+        :where(.light) .home-new {
+          --home-bg: #f8fafc;
+          --home-surface: rgba(255, 255, 255, 0.92);
+          --home-surface-subtle: rgba(241, 245, 249, 0.6);
+          --home-border: rgba(15, 23, 42, 0.08);
+          --home-border-strong: rgba(15, 23, 42, 0.18);
+          --home-ink: #0f172a;
+          --home-ink-muted: #475569;
+          --home-ink-soft: #1e293b;
+          --home-primary: #16a34a;
+          --home-primary-soft: rgba(22, 163, 74, 0.12);
+          --home-primary-strong: #0f766e;
+          --home-accent: #0ea5e9;
+          --home-secondary: #6366f1;
+          --home-highlight: rgba(14, 165, 233, 0.22);
+          --home-shadow-lg: 0 40px 70px rgba(15, 23, 42, 0.18);
+          --home-shadow-md: 0 28px 60px rgba(15, 23, 42, 0.12);
+          --home-shadow-sm: 0 20px 45px rgba(15, 23, 42, 0.08);
+        }
+
+        :where(.dark) .home-new {
+          --home-bg: #020617;
+          --home-surface: rgba(15, 23, 42, 0.85);
+          --home-surface-subtle: rgba(15, 23, 42, 0.65);
+          --home-border: rgba(148, 163, 184, 0.22);
+          --home-border-strong: rgba(148, 163, 184, 0.35);
+          --home-ink: rgba(226, 232, 240, 0.96);
+          --home-ink-muted: rgba(148, 163, 184, 0.82);
+          --home-ink-soft: rgba(203, 213, 225, 0.9);
+          --home-primary: #22c55e;
+          --home-primary-soft: rgba(34, 197, 94, 0.18);
+          --home-primary-strong: #38bdf8;
+          --home-accent: #38bdf8;
+          --home-secondary: #a855f7;
+          --home-highlight: rgba(59, 130, 246, 0.35);
+          --home-shadow-lg: 0 50px 90px rgba(2, 6, 23, 0.65);
+          --home-shadow-md: 0 35px 70px rgba(2, 6, 23, 0.45);
+          --home-shadow-sm: 0 25px 55px rgba(2, 6, 23, 0.32);
+        }
+
+        .home-new {
+          min-height: 100vh;
+          background:
+            radial-gradient(120% 80% at 15% -10%, rgba(14, 165, 233, 0.15), transparent 60%),
+            radial-gradient(150% 80% at 90% 10%, rgba(34, 197, 94, 0.18), transparent 70%),
+            var(--home-bg);
+          font-family: 'Inter', 'SF Pro Display', 'Segoe UI', system-ui, sans-serif;
+          color: var(--home-ink);
+        }
+
+        .home-shell {
+          width: min(1200px, 92vw);
+          margin: 0 auto;
+          padding: 4rem 0 6rem;
+          display: flex;
+          flex-direction: column;
+          gap: 6rem;
+        }
+
+        @media (max-width: 960px) {
+          .home-shell {
+            gap: 4rem;
+            padding-top: 3rem;
+            padding-bottom: 5rem;
+          }
+        }
+
+        .home-header {
+          display: flex;
+          align-items: center;
+          gap: 2rem;
+          padding: 1.25rem 1.5rem;
+          border-radius: 999px;
+          background: linear-gradient(120deg, rgba(255, 255, 255, 0.65), rgba(255, 255, 255, 0.35));
+          backdrop-filter: blur(14px);
+          border: 1px solid var(--home-border);
+          box-shadow: var(--home-shadow-sm);
+          position: sticky;
+          top: 1.5rem;
+          z-index: 10;
+        }
+
+        :where(.dark) .home-header {
+          background: linear-gradient(120deg, rgba(15, 23, 42, 0.9), rgba(15, 23, 42, 0.65));
+        }
+
+        .home-logo {
+          display: flex;
+          flex-direction: column;
+          line-height: 1.1;
+        }
+
+        .home-logo__brand {
+          font-size: 1rem;
+          font-weight: 700;
+          letter-spacing: -0.02em;
+        }
+
+        .home-logo__tagline {
+          font-size: 0.75rem;
+          color: var(--home-ink-muted);
+        }
+
+        .home-nav {
+          display: flex;
+          gap: 1.25rem;
+          margin-left: auto;
+          margin-right: auto;
+          font-size: 0.95rem;
+        }
+
+        .home-nav button {
+          background: none;
+          border: none;
+          color: inherit;
+          font: inherit;
+          padding: 0.4rem 0.65rem;
+          border-radius: 999px;
+          cursor: pointer;
+          transition: background 0.2s ease, color 0.2s ease;
+        }
+
+        .home-nav button:focus-visible {
+          outline: 2px solid var(--home-primary);
+          outline-offset: 2px;
+        }
+
+        .home-nav button:hover {
+          background: var(--home-primary-soft);
+          color: var(--home-primary-strong);
+        }
+
+        .home-actions {
+          display: flex;
+          align-items: center;
+          gap: 0.75rem;
+        }
+
+        .home-theme-toggle {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.45rem;
+          padding: 0.55rem 0.85rem;
+          border-radius: 999px;
+          border: 1px solid var(--home-border);
+          background: var(--home-surface);
+          color: var(--home-ink-muted);
+          font-size: 0.9rem;
+          font-weight: 600;
+          transition: background 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
+        }
+
+        .home-theme-toggle:hover {
+          background: var(--home-primary-soft);
+          color: var(--home-primary-strong);
+          box-shadow: var(--home-shadow-sm);
+        }
+
+        .home-theme-toggle__icon svg {
+          width: 1.05rem;
+          height: 1.05rem;
+        }
+
+        .home-theme-toggle__label {
+          white-space: nowrap;
+        }
+
+        .home-actions__login {
+          padding: 0.55rem 1rem;
+          border-radius: 999px;
+          border: 1px solid var(--home-border-strong);
+          background: var(--home-surface);
+          color: var(--home-ink-soft);
+          font-weight: 600;
+          transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .home-actions__login:hover {
+          transform: translateY(-1px);
+          box-shadow: var(--home-shadow-sm);
+        }
+
+        .home-hero {
+          display: grid;
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+          gap: 3.5rem;
+          align-items: center;
+        }
+
+        @media (max-width: 960px) {
+          .home-header {
+            flex-wrap: wrap;
+            justify-content: center;
+            border-radius: 24px;
+          }
+
+          .home-nav {
+            flex-wrap: wrap;
+            justify-content: center;
+            margin-inline: 0;
+          }
+
+          .home-hero {
+            grid-template-columns: 1fr;
+            gap: 2.75rem;
+          }
+        }
+
+        .home-hero__eyebrow {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.5rem;
+          padding: 0.35rem 0.75rem;
+          border-radius: 999px;
+          background: var(--home-primary-soft);
+          color: var(--home-primary-strong);
+          font-weight: 600;
+          font-size: 0.9rem;
+        }
+
+        .home-hero__title {
+          margin-top: 1.2rem;
+          font-size: clamp(2.6rem, 3.2vw + 1rem, 3.8rem);
+          letter-spacing: -0.04em;
+          line-height: 1.05;
+          font-weight: 700;
+        }
+
+        .home-hero__title strong {
+          color: var(--home-primary-strong);
+          font-weight: inherit;
+        }
+
+        .home-hero__description {
+          margin-top: 1.25rem;
+          font-size: 1.1rem;
+          color: var(--home-ink-muted);
+          line-height: 1.6;
+          max-width: 32rem;
+        }
+
+        .home-hero__cta {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 1rem;
+          margin-top: 2rem;
+        }
+
+        .home-hero__cta button {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.5rem;
+          border-radius: 999px;
+          padding: 0.9rem 1.6rem;
+          font-weight: 600;
+          font-size: 1rem;
+          cursor: pointer;
+          border: none;
+          transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .home-hero__cta-primary {
+          background: linear-gradient(120deg, var(--home-primary), var(--home-primary-strong));
+          color: white;
+          box-shadow: var(--home-shadow-md);
+        }
+
+        .home-hero__cta-primary:hover {
+          transform: translateY(-2px);
+        }
+
+        .home-hero__cta-secondary {
+          background: var(--home-surface);
+          color: var(--home-ink-soft);
+          border: 1px solid var(--home-border);
+        }
+
+        .home-hero__cta-secondary:hover {
+          transform: translateY(-2px);
+          box-shadow: var(--home-shadow-sm);
+        }
+
+        .home-hero__media {
+          position: relative;
+          padding: 1.25rem;
+          border-radius: 36px;
+          background: linear-gradient(140deg, var(--home-surface), var(--home-surface-subtle));
+          border: 1px solid var(--home-border);
+          box-shadow: var(--home-shadow-lg);
+        }
+
+        .home-hero__media::after {
+          content: '';
+          position: absolute;
+          inset: 2.5rem;
+          border-radius: 32px;
+          border: 1px dashed var(--home-border);
+          pointer-events: none;
+        }
+
+        .home-hero__media img {
+          display: block;
+          width: 100%;
+          height: auto;
+          border-radius: 24px;
+          box-shadow: 0 15px 40px rgba(15, 23, 42, 0.15);
+        }
+
+        .home-feature-grid {
+          display: grid;
+          gap: 1.5rem;
+          grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+        }
+
+        .home-feature {
+          padding: 1.4rem 1.6rem;
+          border-radius: 24px;
+          background: var(--home-surface);
+          border: 1px solid var(--home-border);
+          box-shadow: var(--home-shadow-sm);
+          display: grid;
+          gap: 0.75rem;
+        }
+
+        .home-feature__icon {
+          width: 2.5rem;
+          height: 2.5rem;
+          border-radius: 18px;
+          display: grid;
+          place-items: center;
+          background: var(--home-primary-soft);
+          color: var(--home-primary-strong);
+        }
+
+        .home-feature__title {
+          font-weight: 600;
+          font-size: 1.05rem;
+        }
+
+        .home-feature__description {
+          color: var(--home-ink-muted);
+          font-size: 0.95rem;
+          line-height: 1.55;
+        }
+
+        .home-metrics {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+          gap: 1.25rem;
+          padding: 1.5rem;
+          border-radius: 24px;
+          background: linear-gradient(140deg, var(--home-surface), var(--home-surface-subtle));
+          border: 1px solid var(--home-border);
+          box-shadow: var(--home-shadow-sm);
+        }
+
+        .home-metric {
+          display: flex;
+          flex-direction: column;
+          gap: 0.4rem;
+        }
+
+        .home-metric__value {
+          font-size: 1.8rem;
+          font-weight: 700;
+          letter-spacing: -0.03em;
+        }
+
+        .home-metric__label {
+          color: var(--home-ink-muted);
+          font-size: 0.9rem;
+          line-height: 1.45;
+        }
+
+        .home-marketplace {
+          display: grid;
+          gap: 3rem;
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+          align-items: center;
+        }
+
+        @media (max-width: 900px) {
+          .home-marketplace {
+            grid-template-columns: 1fr;
+            gap: 2.5rem;
+          }
+        }
+
+        .home-marketplace__media {
+          background: linear-gradient(150deg, var(--home-surface), var(--home-highlight));
+          padding: 1.75rem;
+          border-radius: 32px;
+          border: 1px solid var(--home-border);
+          box-shadow: var(--home-shadow-md);
+        }
+
+        .home-marketplace__media img {
+          width: 100%;
+          height: auto;
+          display: block;
+        }
+
+        .home-marketplace__heading {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.5rem;
+          font-weight: 600;
+          color: var(--home-primary-strong);
+          background: var(--home-primary-soft);
+          padding: 0.35rem 0.8rem;
+          border-radius: 999px;
+          font-size: 0.95rem;
+        }
+
+        .home-marketplace__title {
+          font-size: clamp(2rem, 1.8rem + 1vw, 2.6rem);
+          letter-spacing: -0.03em;
+          margin-top: 1rem;
+          font-weight: 700;
+        }
+
+        .home-marketplace__description {
+          margin-top: 1rem;
+          color: var(--home-ink-muted);
+          line-height: 1.6;
+        }
+
+        .home-marketplace__pills {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 0.6rem;
+          margin-top: 1.5rem;
+        }
+
+        .home-marketplace__pill {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.4rem;
+          padding: 0.55rem 0.9rem;
+          border-radius: 999px;
+          border: 1px solid var(--home-border);
+          background: var(--home-surface);
+          font-size: 0.9rem;
+          font-weight: 500;
+        }
+
+        .home-sections__heading {
+          display: flex;
+          flex-direction: column;
+          gap: 0.6rem;
+        }
+
+        .home-sections {
+          display: grid;
+          gap: 2.5rem;
+        }
+
+        .home-sections__eyebrow {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.45rem;
+          background: var(--home-primary-soft);
+          color: var(--home-primary-strong);
+          font-weight: 600;
+          font-size: 0.9rem;
+          padding: 0.35rem 0.75rem;
+          border-radius: 999px;
+          width: fit-content;
+        }
+
+        .home-sections__title {
+          font-size: clamp(2.1rem, 1.5rem + 1.5vw, 2.8rem);
+          letter-spacing: -0.03em;
+          font-weight: 700;
+        }
+
+        .home-sections__description {
+          font-size: 1.05rem;
+          color: var(--home-ink-muted);
+          line-height: 1.65;
+          max-width: 40rem;
+        }
+
+        .home-modules {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+          gap: 1.5rem;
+        }
+
+        .home-module {
+          position: relative;
+          overflow: hidden;
+          border-radius: 28px;
+          border: 1px solid var(--home-border);
+          background: linear-gradient(160deg, var(--home-surface), var(--home-surface-subtle));
+          box-shadow: var(--home-shadow-sm);
+          display: grid;
+          gap: 1.25rem;
+          padding: 1.75rem 1.5rem 1.5rem;
+        }
+
+        .home-module__media {
+          border-radius: 20px;
+          overflow: hidden;
+          background: var(--home-highlight);
+          border: 1px solid var(--home-border);
+        }
+
+        .home-module__media img {
+          width: 100%;
+          height: auto;
+          display: block;
+        }
+
+        .home-module__title {
+          font-size: 1.15rem;
+          font-weight: 600;
+        }
+
+        .home-module__list {
+          display: grid;
+          gap: 0.6rem;
+          color: var(--home-ink-muted);
+          font-size: 0.95rem;
+        }
+
+        .home-module__list-item {
+          display: flex;
+          gap: 0.5rem;
+          align-items: flex-start;
+        }
+
+        .home-module__list-item svg {
+          flex-shrink: 0;
+          color: var(--home-primary-strong);
+        }
+
+        .home-testimonials {
+          display: grid;
+          gap: 1.5rem;
+          grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        }
+
+        .home-testimonial {
+          padding: 1.75rem;
+          border-radius: 28px;
+          border: 1px solid var(--home-border);
+          background: linear-gradient(150deg, var(--home-surface), var(--home-surface-subtle));
+          box-shadow: var(--home-shadow-sm);
+          display: grid;
+          gap: 1.25rem;
+        }
+
+        .home-testimonial__quote {
+          font-size: 1.05rem;
+          line-height: 1.6;
+        }
+
+        .home-testimonial__author {
+          color: var(--home-ink-muted);
+          font-weight: 600;
+        }
+
+        .home-cta {
+          border-radius: 36px;
+          padding: 3.5rem clamp(1.5rem, 6vw, 4rem);
+          background: linear-gradient(120deg, var(--home-primary), var(--home-secondary));
+          color: white;
+          display: grid;
+          gap: 1.5rem;
+          box-shadow: var(--home-shadow-lg);
+        }
+
+        .home-cta__title {
+          font-size: clamp(2.2rem, 2rem + 1vw, 2.8rem);
+          letter-spacing: -0.04em;
+          font-weight: 700;
+        }
+
+        .home-cta__actions {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 1rem;
+        }
+
+        .home-cta__actions button {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.5rem;
+          border-radius: 999px;
+          padding: 0.9rem 1.6rem;
+          font-weight: 600;
+          cursor: pointer;
+          border: none;
+        }
+
+        .home-cta__actions button:nth-child(2) {
+          background: rgba(15, 23, 42, 0.18);
+        }
+
+        .home-cta__actions button:nth-child(2):hover {
+          background: rgba(15, 23, 42, 0.26);
+        }
+
+        .home-cta__actions button:focus-visible {
+          outline: 2px solid rgba(255, 255, 255, 0.8);
+          outline-offset: 3px;
+        }
+
+        @media (max-width: 720px) {
+          .home-header {
+            padding: 1rem;
+          }
+
+          .home-actions {
+            width: 100%;
+            justify-content: center;
+          }
+
+          .home-theme-toggle__label {
+            display: none;
+          }
+
+          .home-cta {
+            border-radius: 28px;
+            text-align: center;
+          }
+
+          .home-cta__actions {
+            justify-content: center;
+          }
+        }
+      `}</style>
+
+      <div className="home-shell">
+        <header className="home-header" aria-label="Navegação principal">
+          <div className="home-logo">
+            <span className="home-logo__brand">MeuCondomínio</span>
+            <span className="home-logo__tagline">Gestão completa para condomínios</span>
+          </div>
+
+          <nav className="home-nav" aria-label="Seções do site">
+            {NAVIGATION_LINKS.map(({ href, label }) => (
+              <button key={href} type="button" onClick={() => onNavigate(href)}>
+                {label}
+              </button>
+            ))}
+          </nav>
+
+          <div className="home-actions">
+            <ThemeToggle className="home-actions__toggle" />
+            <button type="button" className="home-actions__login" onClick={onLogin}>
+              Entrar
+            </button>
+          </div>
+        </header>
+
+        <section className="home-hero">
+          <div>
+            <span className="home-hero__eyebrow">
+              <Sparkles size={18} strokeWidth={1.8} />
+              Plataforma tudo-em-um para síndicos visionários
+            </span>
+            <h1 className="home-hero__title">
+              Transforme a gestão do seu condomínio com uma experiência <strong>premium</strong> para todos.
+            </h1>
+            <p className="home-hero__description">
+              Centralize finanças, comunicação e operações em um único painel inteligente. Simplifique o trabalho do síndico, encante moradores e reduza custos com automações reais.
+            </p>
+            <div className="home-hero__cta">
+              <button
+                type="button"
+                className="home-hero__cta-primary"
+                onClick={() => onNavigate('/solucoes')}
+              >
+                Explorar soluções
+                <ArrowRight size={18} strokeWidth={1.8} />
+              </button>
+              <button
+                type="button"
+                className="home-hero__cta-secondary"
+                onClick={() => onNavigate('/precos')}
+              >
+                Ver planos
+              </button>
+            </div>
+
+            <div className="home-feature-grid" aria-label="Diferenciais do MeuCondomínio">
+              {HERO_FEATURES.map(({ title, description, icon: Icon }) => (
+                <article key={title} className="home-feature">
+                  <span className="home-feature__icon">
+                    <Icon size={20} strokeWidth={1.8} />
+                  </span>
+                  <h2 className="home-feature__title">{title}</h2>
+                  <p className="home-feature__description">{description}</p>
+                </article>
+              ))}
+            </div>
+          </div>
+
+          <div className="home-hero__media">
+            <img
+              src="/assets/marketing/hero.svg"
+              alt="Aplicativo MeuCondomínio exibindo dashboards e marketplace"
+              width={960}
+              height={800}
+              fetchpriority="high"
+              decoding="async"
+              srcSet="/assets/marketing/hero.svg 960w"
+              sizes="(max-width: 960px) 90vw, 480px"
+            />
+          </div>
+        </section>
+
+        <section className="home-metrics" aria-label="Resultados comprovados">
+          {METRICS.map((metric) => (
+            <article key={metric.value} className="home-metric">
+              <span className="home-metric__value">{metric.value}</span>
+              <span className="home-metric__label">{metric.label}</span>
+            </article>
+          ))}
+        </section>
+
+        <section className="home-marketplace">
+          <div className="home-marketplace__media">
+            <img
+              src="/assets/marketing/market-illus.svg"
+              alt="Tela do marketplace com vitrine de serviços para moradores"
+              width={720}
+              height={540}
+              loading="lazy"
+              decoding="async"
+              srcSet="/assets/marketing/market-illus.svg 720w"
+              sizes="(max-width: 900px) 90vw, 420px"
+            />
+          </div>
+
+          <div>
+            <span className="home-marketplace__heading">
+              <ShieldCheck size={18} strokeWidth={1.8} />
+              Marketplace interno
+            </span>
+            <h2 className="home-marketplace__title">
+              Um marketplace seguro para gerar receita dentro do condomínio.
+            </h2>
+            <p className="home-marketplace__description">
+              Conecte moradores, fornecedores e o síndico em um ambiente com curadoria. Aprove o que vai ao ar, crie promoções, receba pagamentos instantaneamente e acompanhe indicadores em tempo real.
+            </p>
+            <div className="home-marketplace__pills">
+              {MARKETPLACE_PILLS.map((pill) => (
+                <span key={pill} className="home-marketplace__pill">
+                  <CheckCircle2 size={16} strokeWidth={1.8} />
+                  {pill}
+                </span>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section aria-labelledby="modulos-titulo" className="home-sections">
+          <header className="home-sections__heading">
+            <span className="home-sections__eyebrow">
+              <Sparkles size={18} strokeWidth={1.8} />
+              Módulos que trabalham por você
+            </span>
+            <h2 id="modulos-titulo" className="home-sections__title">
+              Automação de ponta a ponta para equipes enxutas.
+            </h2>
+            <p className="home-sections__description">
+              Organize finanças, relacionamento com moradores e operações com fluxos que seguem as melhores práticas do mercado condominial brasileiro.
+            </p>
+          </header>
+
+          <div className="home-modules">
+            {MODULES.map(({ title, points, media }) => (
+              <article key={title} className="home-module">
+                <div className="home-module__media">
+                  <img
+                    src={media.src}
+                    alt={title}
+                    width={media.width}
+                    height={media.height}
+                    loading="lazy"
+                    decoding="async"
+                    srcSet={`${media.src} ${media.width}w`}
+                    sizes="(max-width: 720px) 90vw, 320px"
+                  />
+                </div>
+                <h3 className="home-module__title">{title}</h3>
+                <div className="home-module__list">
+                  {points.map((point) => (
+                    <span key={point} className="home-module__list-item">
+                      <Star size={16} strokeWidth={1.6} />
+                      {point}
+                    </span>
+                  ))}
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section aria-labelledby="depoimentos-titulo" className="home-sections">
+          <header className="home-sections__heading">
+            <span className="home-sections__eyebrow">
+              <ShieldCheck size={18} strokeWidth={1.8} />
+              Histórias reais de síndicos
+            </span>
+            <h2 id="depoimentos-titulo" className="home-sections__title">
+              Resultados consistentes do Norte ao Sul do Brasil.
+            </h2>
+          </header>
+
+          <div className="home-testimonials">
+            {TESTIMONIALS.map(({ quote, author }) => (
+              <article key={author} className="home-testimonial">
+                <p className="home-testimonial__quote">{quote}</p>
+                <span className="home-testimonial__author">{author}</span>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="home-cta" aria-label="Agende uma demonstração">
+          <div>
+            <h2 className="home-cta__title">Pronto para elevar o padrão do seu condomínio?</h2>
+            <p>
+              Agende uma demonstração gratuita, veja os fluxos em ação e descubra como o MeuCondomínio pode reduzir custos em semanas.
+            </p>
+          </div>
+          <div className="home-cta__actions">
+            <button type="button" onClick={() => onNavigate('/solucoes')}>
+              Agendar demonstração
+              <ArrowRight size={18} strokeWidth={1.8} />
+            </button>
+            <button type="button" onClick={() => onNavigate('/sobre')}>
+              Conhecer nossa história
+            </button>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- rebuild the HomeNew marketing page with a condensed Marketing Screens inspired layout and refined tokenized styling
- integrate the existing marketing illustrations with responsive metadata and align the sections, metrics, and testimonials to the new visual rhythm
- polish the header controls with the persisted theme toggle and login entry point matching the refreshed palette

## Testing
- npm run build *(fails: Cannot find type definition file for '@testing-library/jest-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68f05440aea483339468e595c848eabb