### PR TITLE
Revamp hero layout with marketplace steps and dashboard mockup

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -9,8 +9,8 @@ type HeroProps = {
 };
 
 const HEADLINES: Record<HeroVariant, string> = {
-  A: 'Seu condomínio 10x mais eficiente.',
-  B: 'Gestão séria. Vida leve.',
+  A: 'Menos inadimplência, mais controle e síndico em paz.',
+  B: 'Menos inadimplência, mais controle e síndico em paz.',
 };
 
 const KPI_CARDS = [
@@ -41,13 +41,11 @@ export default function Hero({ variant = 'A', onPrimaryClick, onSecondaryClick }
             <span className="text-sm font-medium uppercase tracking-[0.2em] text-emerald-600 dark:text-emerald-300">
               {PROOF_COPY}
             </span>
-            <h1 id="hero-heading" className="text-4xl font-bold tracking-tight text-emerald-900 dark:text-emerald-100 sm:text-5xl">
+            <h1 id="hero-heading" className="text-4xl font-bold leading-tight tracking-tight text-emerald-900 dark:text-emerald-100 sm:text-5xl">
               {headline}
             </h1>
             <p className="text-lg leading-relaxed text-slate-700 dark:text-slate-200">
-              Reduza a inadimplência em <span className="font-semibold text-emerald-700 dark:text-emerald-300">35%</span> e elimine{' '}
-              <span className="font-semibold text-emerald-700 dark:text-emerald-300">40h/mês</span> de tarefas manuais com financeiro automatizado,
-              assembleia digital e marketplace integrado.
+              Redução real da inadimplência, financeiro automatizado, assembleia digital sem dor de cabeça e marketplace pronto para serviços.
             </p>
           </div>
 
@@ -88,41 +86,93 @@ export default function Hero({ variant = 'A', onPrimaryClick, onSecondaryClick }
               </span>
               Marketplace no condomínio: contrate serviços sem sair do app.
             </Badge>
+
+            <div className="flex flex-wrap items-center gap-2 rounded-2xl border border-emerald-100/80 bg-white/80 p-3 shadow-sm shadow-emerald-900/5 backdrop-blur dark:border-emerald-500/20 dark:bg-emerald-900/40">
+              {[1, 2, 3].map((step) => (
+                <div
+                  key={step}
+                  className="flex items-center gap-2 rounded-xl bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-900 shadow-sm shadow-emerald-900/5 dark:bg-emerald-800/60 dark:text-emerald-50"
+                >
+                  <span className="flex h-7 w-7 items-center justify-center rounded-full bg-emerald-900 text-xs font-bold text-white shadow-sm shadow-emerald-900/20 dark:bg-emerald-400 dark:text-emerald-950">
+                    {step}
+                  </span>
+                  {step === 1 && 'Cadastre seu condomínio'}
+                  {step === 2 && 'Conecte financeiro e regras'}
+                  {step === 3 && 'Ative o marketplace de serviços'}
+                </div>
+              ))}
+            </div>
           </div>
         </div>
 
         <div className="relative mx-auto flex w-full max-w-xl flex-col items-stretch justify-center gap-6 lg:mx-0">
           <div className="relative overflow-hidden rounded-2xl border border-white/40 bg-white/80 p-6 shadow-xl shadow-emerald-900/10 backdrop-blur-sm dark:border-emerald-500/10 dark:bg-emerald-900/40">
-            <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-emerald-500/20 via-emerald-400/10 to-emerald-900/30" aria-hidden="true" />
+            <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-emerald-500/15 via-emerald-400/10 to-emerald-900/25" aria-hidden="true" />
             <div className="relative flex flex-col gap-5">
               <div className="flex items-center justify-between text-sm font-medium text-emerald-900/80 dark:text-emerald-100/90">
-                <span>Resumo do condomínio</span>
-                <span>Atualizado agora</span>
+                <span>Painel financeiro</span>
+                <span className="flex items-center gap-2 text-xs font-semibold text-emerald-700 dark:text-emerald-200">
+                  <span className="h-2 w-2 rounded-full bg-emerald-400" aria-hidden="true" />
+                  Online
+                </span>
               </div>
-              <div className="grid gap-4">
+
+              <div className="grid gap-4 sm:grid-cols-2">
                 {KPI_CARDS.map((kpi) => (
-                  <div key={kpi.label} className="flex items-center justify-between rounded-xl bg-white/80 px-4 py-3 text-left shadow-sm shadow-emerald-900/5 backdrop-blur-sm dark:bg-emerald-950/60">
-                    <div className="flex flex-col">
+                  <div key={kpi.label} className="flex flex-col gap-2 rounded-xl bg-white/90 p-4 text-left shadow-sm shadow-emerald-900/5 backdrop-blur-sm dark:bg-emerald-950/60">
+                    <div className="flex items-center justify-between">
                       <span className="text-sm font-medium text-slate-600 dark:text-slate-200">{kpi.label}</span>
-                      <span className="text-xs text-slate-500 dark:text-slate-300">Mensal</span>
+                      <span className={`rounded-full px-3 py-1 text-sm font-semibold ${kpi.trend}`}>
+                        {kpi.value}
+                      </span>
                     </div>
-                    <span className={`rounded-full px-3 py-1 text-sm font-semibold ${kpi.trend}`}>
-                      {kpi.value}
-                    </span>
+                    <div className="h-2 rounded-full bg-emerald-100 dark:bg-emerald-800/50">
+                      <div className="h-full w-[75%] rounded-full bg-gradient-to-r from-emerald-400 to-emerald-600" aria-hidden="true" />
+                    </div>
+                    <p className="text-xs text-slate-500 dark:text-slate-300">Comparativo mensal com metas do síndico.</p>
                   </div>
                 ))}
               </div>
-              <div className="flex flex-col gap-2 rounded-xl bg-emerald-900/90 p-4 text-emerald-50 shadow-inner shadow-emerald-900/40">
-                <div className="flex items-center justify-between text-sm">
-                  <span>Taxa de resolução</span>
-                  <span className="font-semibold">98%</span>
+
+              <div className="flex flex-col gap-3 rounded-xl bg-emerald-900/90 p-4 text-emerald-50 shadow-inner shadow-emerald-900/40">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <span className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-400/90 text-sm font-bold text-emerald-900 shadow-sm shadow-emerald-900/30">
+                      MC
+                    </span>
+                    <div className="flex flex-col">
+                      <span className="text-sm font-semibold">Reserva do Lago</span>
+                      <span className="text-xs text-emerald-50/80">Síndico com visão consolidada</span>
+                    </div>
+                  </div>
+                  <span className="rounded-full bg-white/10 px-3 py-1 text-xs font-semibold text-emerald-50">+18% caixa</span>
                 </div>
-                <div className="h-2 rounded-full bg-emerald-700/60">
-                  <div className="h-full w-[82%] rounded-full bg-emerald-400" aria-hidden="true" />
+                <div className="h-32 rounded-lg bg-emerald-800/70">
+                  <div className="flex h-full items-end gap-2 px-3 pb-3">
+                    {[55, 78, 64, 92, 80].map((value, index) => (
+                      <div key={index} className="flex h-full flex-1 items-end">
+                        <div
+                          className="w-full rounded-md bg-gradient-to-t from-emerald-500 to-emerald-300 shadow-inner shadow-emerald-900/30"
+                          style={{ height: `${value}%` }}
+                        />
+                      </div>
+                    ))}
+                  </div>
                 </div>
-                <p className="text-xs text-emerald-50/80">
-                  Suporte 7x12 com SLA de 30 minutos garante moradores satisfeitos.
-                </p>
+                <div className="grid grid-cols-3 gap-3 text-xs">
+                  <div className="rounded-lg bg-white/10 p-3 text-center">
+                    <div className="text-2xl font-semibold">92%</div>
+                    <div className="text-emerald-50/80">Cobranças automáticas</div>
+                  </div>
+                  <div className="rounded-lg bg-white/10 p-3 text-center">
+                    <div className="text-2xl font-semibold">48h</div>
+                    <div className="text-emerald-50/80">Tempo médio de acordo</div>
+                  </div>
+                  <div className="rounded-lg bg-white/10 p-3 text-center">
+                    <div className="text-2xl font-semibold">+36</div>
+                    <div className="text-emerald-50/80">Serviços no marketplace</div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Update hero headline and subtitle to highlight practical results and benefits
- Add horizontal step strip outlining cadastro, conexão financeira e marketplace
- Replace hero illustration with a dashboard-style mockup using existing emerald palette

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f8d86c5e4833390c877fe5a32b785)