### PR TITLE
Refatora página de suporte com métricas e chips de canais

### DIFF
--- a/components/marketing/MarketingLayout.tsx
+++ b/components/marketing/MarketingLayout.tsx
@@ -334,6 +334,103 @@ export function MarketingLayout({
           color: var(--brand);
         }
 
+        .marketing-hero-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+          gap: 20px;
+          align-items: stretch;
+        }
+
+        .marketing-hero-card {
+          height: 100%;
+          display: flex;
+          flex-direction: column;
+          gap: 14px;
+        }
+
+        .marketing-hero-card__header {
+          display: flex;
+          align-items: flex-start;
+          justify-content: space-between;
+          gap: 12px;
+        }
+
+        .marketing-card-title {
+          margin: 10px 0 0;
+          font-size: 16px;
+          color: var(--text);
+        }
+
+        .marketing-hero-card__metrics {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+          gap: 12px;
+        }
+
+        .marketing-hero-card__metric {
+          background: var(--bg-soft);
+          border: 1px solid var(--border);
+          border-radius: 12px;
+          padding: 12px;
+          box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
+        }
+
+        .marketing-hero-card__metric-value {
+          font-weight: 800;
+          font-size: 18px;
+          color: var(--brand);
+        }
+
+        .marketing-hero-card__metric-label {
+          font-weight: 700;
+          color: var(--text);
+        }
+
+        .marketing-hero-card__metric-detail {
+          margin: 6px 0 0;
+          color: var(--text-muted);
+          font-size: 13px;
+        }
+
+        .marketing-chip-row {
+          display: flex;
+          gap: 8px;
+          flex-wrap: wrap;
+        }
+
+        .marketing-chip {
+          display: inline-flex;
+          align-items: center;
+          padding: 6px 10px;
+          border-radius: 999px;
+          background: rgba(32, 201, 151, 0.12);
+          color: var(--text);
+          font-weight: 600;
+          border: 1px solid var(--border);
+          font-size: 13px;
+        }
+
+        .marketing-status-row {
+          display: inline-flex;
+          align-items: center;
+          gap: 8px;
+          font-weight: 700;
+          color: var(--text);
+        }
+
+        .marketing-status-dot {
+          width: 10px;
+          height: 10px;
+          border-radius: 999px;
+          background: linear-gradient(135deg, #22c55e, #16a34a);
+          box-shadow: 0 0 0 6px rgba(34, 197, 94, 0.12);
+        }
+
+        .marketing-status-label {
+          color: var(--text-muted);
+          font-weight: 600;
+        }
+
         .marketing-cta,
         .marketing-cta-secondary {
           padding: 10px 16px;

--- a/components/marketing/SuportePage.tsx
+++ b/components/marketing/SuportePage.tsx
@@ -7,17 +7,30 @@ const CANAIS = [
     descricao:
       'Base de conhecimento com passo a passo, vídeos curtos e checklists imprimíveis para a equipe do condomínio.',
     detalhes: ['+200 artigos revisados todo mês', 'Pesquisa inteligente com IA', 'Tradução automática para inglês e espanhol'],
+    canais: ['Pesquisa inteligente', 'Artigos', 'Vídeos', 'Modelos prontos'],
+    status: 'Disponível agora',
+    cta: { label: 'Acessar central de ajuda', href: '/central-ajuda' },
   },
   {
     titulo: 'Suporte humano em múltiplos canais',
     descricao: 'Atendimento por chat, e-mail e WhatsApp com SLA garantido e monitoramento de satisfação em tempo real.',
     detalhes: ['SLA de 2 minutos no chat', 'Histórico completo de interações', 'Escalonamento para especialistas financeiros'],
+    canais: ['Chat', 'E-mail', 'WhatsApp', 'Telefone'],
+    status: 'Disponível agora',
   },
   {
     titulo: 'Universidade MeuCondomínio',
     descricao: 'Treinamentos ao vivo e gravados para síndicos, conselheiros e equipes operacionais.',
     detalhes: ['Trilhas por perfil', 'Certificação de síndicos', 'Workshops exclusivos para administradoras'],
+    canais: ['Ao vivo', 'Vídeos', 'Certificações', 'Workshops'],
+    status: 'Turmas semanais',
   },
+];
+
+const HERO_METRICAS = [
+  { titulo: 'SLA médio', valor: '2 minutos no chat', detalhe: 'Atendimento priorizado por criticidade' },
+  { titulo: 'NPS de suporte', valor: '92', detalhe: 'Monitorado em tempo real a cada chamado' },
+  { titulo: 'Horários de atendimento', valor: '7h às 19h (BRT)', detalhe: 'Plantão emergencial fora do horário' },
 ];
 
 const STATUS = [
@@ -34,16 +47,40 @@ export function MarketingSuportePage({ onNavigate, onLogin }: MarketingPageProps
   return (
     <MarketingLayout currentPath="/suporte" onNavigate={onNavigate} onLogin={onLogin}>
       <section className="marketing-section" aria-labelledby="suporte-heading">
-        <div className="marketing-section-header">
-          <span className="marketing-badge" aria-hidden="true">
-            Estamos com você
-          </span>
-          <h1 id="suporte-heading" className="marketing-title">
-            Suporte humano com velocidade de tecnologia.
-          </h1>
-          <p className="marketing-lead">
-            Nossa equipe acompanha sua operação todos os dias para garantir moradores satisfeitos e síndicos tranquilos.
-          </p>
+        <div className="marketing-hero-grid">
+          <div className="marketing-section-header">
+            <span className="marketing-badge" aria-hidden="true">
+              Estamos com você
+            </span>
+            <h1 id="suporte-heading" className="marketing-title">
+              Suporte humano com velocidade de tecnologia.
+            </h1>
+            <p className="marketing-lead">
+              Nossa equipe acompanha sua operação todos os dias para garantir moradores satisfeitos e síndicos tranquilos.
+            </p>
+          </div>
+
+          <article className="marketing-card marketing-hero-card" aria-label="Métricas de suporte em tempo real">
+            <header className="marketing-hero-card__header">
+              <div>
+                <span className="marketing-badge" aria-hidden="true">
+                  Monitoramento 24/7
+                </span>
+                <h2 className="marketing-card-title">Indicadores operacionais</h2>
+              </div>
+              <span className="marketing-status-dot" aria-label="Status do suporte" />
+            </header>
+
+            <div className="marketing-hero-card__metrics">
+              {HERO_METRICAS.map((item) => (
+                <div key={item.titulo} className="marketing-hero-card__metric" aria-label={item.titulo}>
+                  <div className="marketing-hero-card__metric-value">{item.valor}</div>
+                  <div className="marketing-hero-card__metric-label">{item.titulo}</div>
+                  <p className="marketing-hero-card__metric-detail">{item.detalhe}</p>
+                </div>
+              ))}
+            </div>
+          </article>
         </div>
       </section>
 
@@ -57,6 +94,17 @@ export function MarketingSuportePage({ onNavigate, onLogin }: MarketingPageProps
             <article key={canal.titulo} className="marketing-card" aria-label={canal.titulo}>
               <h3>{canal.titulo}</h3>
               <p>{canal.descricao}</p>
+              <div className="marketing-chip-row" aria-label="Canais disponíveis">
+                {canal.canais.map((canalDisponivel) => (
+                  <span key={canalDisponivel} className="marketing-chip">
+                    {canalDisponivel}
+                  </span>
+                ))}
+              </div>
+              <div className="marketing-status-row" aria-label={`Status: ${canal.status}`}>
+                <span className="marketing-status-dot" aria-hidden="true" />
+                <span className="marketing-status-label">{canal.status}</span>
+              </div>
               <ul className="marketing-list">
                 {canal.detalhes.map((detalhe) => (
                   <li key={detalhe}>
@@ -65,6 +113,18 @@ export function MarketingSuportePage({ onNavigate, onLogin }: MarketingPageProps
                   </li>
                 ))}
               </ul>
+              {canal.cta ? (
+                <a
+                  className="marketing-cta"
+                  href={canal.cta.href}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    onNavigate(canal.cta?.href ?? '/');
+                  }}
+                >
+                  {canal.cta.label}
+                </a>
+              ) : null}
             </article>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- adiciona cartão de métricas no hero com SLA, NPS e horários de atendimento
- enriquece cards de suporte com chips de canais, indicador de status e CTA
- inclui estilos reutilizáveis para grid do hero, chips e indicadores de disponibilidade

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691faafa0544833387a82dcc6aa1c90d)