### PR TITLE
Adjust mobile navigation menu alignment with sidebar

### DIFF
--- a/components/ui/navigation-menu.tsx
+++ b/components/ui/navigation-menu.tsx
@@ -3,24 +3,50 @@ import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
 import { cva } from "class-variance-authority";
 import { ChevronDownIcon } from "lucide-react";
 
+import { useSidebarContext } from "./sidebar";
 import { cn } from "./utils";
 
 function NavigationMenu({
   className,
   children,
   viewport = true,
+  style,
   ...props
 }: React.ComponentProps<typeof NavigationMenuPrimitive.Root> & {
   viewport?: boolean;
 }) {
+  const sidebarContext = useSidebarContext();
+  const isMobileSidebarOpen = Boolean(
+    sidebarContext?.isMobile && sidebarContext.openMobile,
+  );
+
+  const navigationStyle = React.useMemo(() => {
+    if (!isMobileSidebarOpen) {
+      return style;
+    }
+
+    const sidebarWidth = sidebarContext?.isMobile
+      ? "18rem"
+      : "var(--sidebar-width)";
+
+    return {
+      ...style,
+      "--dashboard-nav-width": sidebarWidth,
+    } as React.CSSProperties;
+  }, [isMobileSidebarOpen, sidebarContext?.isMobile, style]);
+
   return (
     <NavigationMenuPrimitive.Root
       data-slot="navigation-menu"
       data-viewport={viewport}
+      data-sidebar-mobile-open={isMobileSidebarOpen}
       className={cn(
         "group/navigation-menu relative flex max-w-max flex-1 items-center justify-center",
+        isMobileSidebarOpen &&
+          "w-[var(--dashboard-nav-width)] justify-start",
         className,
       )}
+      style={navigationStyle}
       {...props}
     >
       {children}
@@ -33,11 +59,18 @@ function NavigationMenuList({
   className,
   ...props
 }: React.ComponentProps<typeof NavigationMenuPrimitive.List>) {
+  const sidebarContext = useSidebarContext();
+  const isMobileSidebarOpen = Boolean(
+    sidebarContext?.isMobile && sidebarContext.openMobile,
+  );
+
   return (
     <NavigationMenuPrimitive.List
       data-slot="navigation-menu-list"
       className={cn(
         "group flex flex-1 list-none items-center justify-center gap-1",
+        isMobileSidebarOpen &&
+          "w-full max-w-[var(--dashboard-nav-width)] flex-col items-stretch justify-start px-1 pb-4",
         className,
       )}
       {...props}

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -44,6 +44,10 @@ type SidebarContextProps = {
 
 const SidebarContext = React.createContext<SidebarContextProps | null>(null);
 
+function useSidebarContext() {
+  return React.useContext(SidebarContext);
+}
+
 function useSidebar() {
   const context = React.useContext(SidebarContext);
   if (!context) {
@@ -722,5 +726,6 @@ export {
   SidebarRail,
   SidebarSeparator,
   SidebarTrigger,
+  useSidebarContext,
   useSidebar,
 };


### PR DESCRIPTION
## Summary
- expose an optional sidebar context hook for components that need sidebar state
- update the navigation menu to align with the mobile sidebar width and add padding when open

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691faf11d1508333b59361dc45c52737)