### PR TITLE
Improve hero mobile spacing and readability

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,5 +1,7 @@
 import { useMemo, useState } from 'react';
 
+import '../../styles/hero.css';
+
 type HeroVariant = 'A' | 'B';
 
 type HeroProps = {
@@ -63,9 +65,14 @@ export default function Hero({ variant = 'A', onPrimaryClick, onSecondaryClick }
   const summaryTitle = useMemo(() => `Resumo do condomínio — ${activeTab}`, [activeTab]);
 
   return (
-    <section className="bg-slate-50 py-16 text-slate-900 dark:bg-slate-950 dark:text-slate-100" aria-labelledby="hero-heading">
-      <div className="mx-auto grid max-w-6xl items-start gap-10 px-4 sm:px-6 lg:grid-cols-[1.05fr_0.95fr] lg:gap-14 lg:px-8">
-        <div className="mx-auto flex w-full max-w-2xl flex-col gap-8 lg:mx-0">
+    <section
+      className="hero-with-bg relative overflow-hidden py-16 text-slate-900 dark:text-slate-100"
+      aria-labelledby="hero-heading"
+    >
+      <div className="hero-overlay" aria-hidden />
+
+      <div className="hero-content relative z-10 mx-auto grid max-w-6xl items-start gap-10 px-4 sm:px-6 lg:grid-cols-[1.05fr_0.95fr] lg:gap-14 lg:px-8">
+        <div className="hero-body mx-auto flex w-full max-w-2xl flex-col gap-8 lg:mx-0">
           <header className="flex flex-col gap-4">
             <span className="text-sm font-medium uppercase tracking-[0.2em] text-emerald-600 dark:text-emerald-300">
               {PROOF_COPY}
@@ -73,7 +80,7 @@ export default function Hero({ variant = 'A', onPrimaryClick, onSecondaryClick }
             <div className="space-y-2">
               <h1
                 id="hero-heading"
-                className="text-4xl font-black leading-tight tracking-tight text-emerald-950 transition-colors duration-200 dark:text-emerald-100 sm:text-5xl"
+                className="hero-headline text-3xl font-black leading-tight tracking-tight text-emerald-950 transition-colors duration-200 dark:text-emerald-100 sm:text-4xl lg:text-5xl"
               >
                 {headline}
               </h1>
@@ -91,7 +98,7 @@ export default function Hero({ variant = 'A', onPrimaryClick, onSecondaryClick }
             </p>
           </header>
 
-          <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:gap-4">
+          <div className="hero-cta-group flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:gap-4">
             <button
               type="button"
               data-cta="primary"

--- a/styles/hero.css
+++ b/styles/hero.css
@@ -1,0 +1,79 @@
+.hero-with-bg {
+  position: relative;
+  isolation: isolate;
+  background-image: url("/assets/marketing/fundo.jpg");
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-color: #f8fafc;
+}
+
+.hero-with-bg .hero-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to right,
+    rgba(15, 23, 42, 0.85),
+    rgba(15, 23, 42, 0.4),
+    rgba(15, 23, 42, 0.15)
+  );
+  pointer-events: none;
+  z-index: 0;
+}
+
+.hero-with-bg .hero-content {
+  position: relative;
+  z-index: 1;
+}
+
+.hero-with-bg .hero-body {
+  gap: 1.75rem;
+}
+
+.hero-with-bg .hero-headline {
+  max-width: 38rem;
+}
+
+.hero-with-bg .hero-cta-group button {
+  min-height: 3.25rem;
+}
+
+@media (max-width: 767px) {
+  .hero-with-bg {
+    padding: 3.75rem 1.25rem;
+    background-position: center top;
+  }
+
+  .hero-with-bg .hero-overlay {
+    background: linear-gradient(
+      to bottom,
+      rgba(15, 23, 42, 0.98),
+      rgba(15, 23, 42, 0.82),
+      rgba(15, 23, 42, 0.6)
+    );
+  }
+
+  .hero-with-bg .hero-content {
+    gap: 2.75rem;
+    padding-inline: 1.25rem;
+  }
+
+  .hero-with-bg .hero-body {
+    gap: 1.5rem;
+  }
+
+  .hero-with-bg .hero-headline {
+    font-size: 1.85rem;
+    line-height: 1.2;
+    letter-spacing: -0.01em;
+  }
+
+  .hero-with-bg .hero-cta-group {
+    gap: 0.85rem;
+  }
+
+  .hero-with-bg .hero-cta-group button {
+    min-height: 3.4rem;
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add dedicated hero classes to manage layout, headline sizing, and CTA spacing on small screens
- strengthen the mobile overlay and adjust padding/gaps to maintain legibility over the background image

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692390f0fbd88333ac7314375a6fb831)