### PR TITLE
Enhance marketing home visuals with new imagery

### DIFF
--- a/components/marketing/HomePage.tsx
+++ b/components/marketing/HomePage.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import Hero from '@/src/components/Hero';
+import '@/styles/marketing-home.css';
 import { MarketingLayout, type MarketingPageProps } from './MarketingLayout';
 
 const HERO_FEATURES = [
@@ -101,7 +102,7 @@ export function MarketingHomePage({ onNavigate, onLogin }: MarketingPageProps) {
       </section>
 
       <section className="marketing-section" aria-labelledby="marketplace-heading">
-        <div className="marketing-highlight-card marketing-card" style={{ gap: 20 }}>
+        <div className="marketing-highlight-card marketing-card marketplace-visual-card">
           <span className="marketing-badge" aria-hidden="true">
             Diferencial exclusivo
           </span>
@@ -169,6 +170,34 @@ export function MarketingHomePage({ onNavigate, onLogin }: MarketingPageProps) {
         </div>
       </section>
 
+      <section className="marketing-section management-section" aria-labelledby="gestao-heading">
+        <div className="management-grid">
+          <div className="management-copy">
+            <span className="marketing-badge" aria-hidden="true">
+              Operações conectadas
+            </span>
+            <h2 id="gestao-heading" className="marketing-tagline">
+              {HERO_FEATURES[2].title}
+            </h2>
+            <p className="marketing-subtitle">{HERO_FEATURES[2].description}</p>
+            <ul className="marketing-list management-list">
+              {MODULES[2].points.map((point) => (
+                <li key={point}>
+                  <strong>•</strong>
+                  <span>{point}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="management-visual">
+            <img
+              src="/assets/marketing/gestao-tecnologia-condominio.png"
+              alt="Gestão do condomínio com tecnologia"
+            />
+          </div>
+        </div>
+      </section>
+
       <section className="marketing-section" aria-labelledby="metricas-heading">
         <div className="marketing-section-header">
           <span className="marketing-badge" aria-hidden="true">
@@ -179,7 +208,7 @@ export function MarketingHomePage({ onNavigate, onLogin }: MarketingPageProps) {
           </h2>
         </div>
 
-        <div className="marketing-metrics">
+        <div className="marketing-metrics metrics-visual">
           {METRICS.map((metric) => (
             <div key={metric.value} className="marketing-metric-card" aria-label={metric.label}>
               <strong>{metric.value}</strong>

--- a/styles/marketing-home.css
+++ b/styles/marketing-home.css
@@ -1,0 +1,136 @@
+/* Marketing Home – Bloco Marketplace */
+.marketplace-visual-card {
+  gap: 20px;
+  position: relative;
+  background: linear-gradient(120deg, rgba(21, 41, 31, 0.9) 0%, rgba(21, 41, 31, 0.78) 35%, rgba(52, 78, 65, 0.62) 60%, rgba(163, 177, 138, 0.35) 100%),
+    url('/assets/marketing/area-comum-condominio.png');
+  background-size: cover;
+  background-position: center;
+  color: #e9e9e9;
+  border-color: rgba(233, 233, 233, 0.22);
+  box-shadow: 0 18px 32px rgba(21, 41, 31, 0.24);
+}
+
+.marketplace-visual-card .marketing-badge {
+  background: rgba(233, 233, 233, 0.1);
+  color: #e9e9e9;
+  border-color: rgba(233, 233, 233, 0.18);
+}
+
+.marketplace-visual-card .marketing-tagline,
+.marketplace-visual-card .marketing-subtitle,
+.marketplace-visual-card .marketing-pill,
+.marketplace-visual-card .marketing-hero-actions a,
+.marketplace-visual-card .marketing-hero-actions a.secondary {
+  color: #e9e9e9;
+}
+
+.marketplace-visual-card .marketing-pill {
+  background: rgba(233, 233, 233, 0.12);
+  border-color: rgba(233, 233, 233, 0.24);
+}
+
+.marketplace-visual-card .marketing-hero-actions a.secondary {
+  background: rgba(233, 233, 233, 0.08);
+  border-color: rgba(233, 233, 233, 0.2);
+}
+
+.marketplace-visual-card .marketing-hero-actions a:hover,
+.marketplace-visual-card .marketing-hero-actions a.secondary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 32px rgba(21, 41, 31, 0.28);
+}
+
+@media (max-width: 768px) {
+  .marketplace-visual-card {
+    background: linear-gradient(120deg, rgba(21, 41, 31, 0.94) 0%, rgba(21, 41, 31, 0.88) 45%, rgba(52, 78, 65, 0.78) 70%, rgba(163, 177, 138, 0.46) 100%),
+      url('/assets/marketing/area-comum-condominio.png');
+  }
+}
+
+/* Marketing Home – Métricas com vista aérea */
+.metrics-visual {
+  position: relative;
+  background: linear-gradient(140deg, rgba(163, 177, 138, 0.28), rgba(96, 117, 107, 0.18)),
+    url('/assets/marketing/vista-aerea-condominio.png');
+  background-size: cover;
+  background-position: center;
+  padding: 24px;
+  border-radius: 20px;
+  border: 1px solid rgba(21, 41, 31, 0.08);
+  box-shadow: 0 16px 28px rgba(21, 41, 31, 0.12);
+  overflow: hidden;
+}
+
+.metrics-visual::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(163, 177, 138, 0.28);
+  mix-blend-mode: multiply;
+  pointer-events: none;
+}
+
+.metrics-visual .marketing-metric-card {
+  position: relative;
+  z-index: 1;
+  background: rgba(233, 233, 233, 0.86);
+  border-color: rgba(21, 41, 31, 0.12);
+  box-shadow: 0 12px 24px rgba(21, 41, 31, 0.14);
+}
+
+/* Marketing Home – Bloco de gestão e automação */
+.management-section {
+  gap: 32px;
+}
+
+.management-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: 1.1fr 0.9fr;
+  align-items: center;
+}
+
+.management-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.management-list {
+  margin-top: 8px;
+}
+
+.management-visual {
+  width: 100%;
+  max-width: 520px;
+  justify-self: end;
+  background: linear-gradient(160deg, rgba(21, 41, 31, 0.75), rgba(52, 78, 65, 0.5)),
+    url('/assets/marketing/fundo.png');
+  background-size: cover;
+  background-position: center;
+  border-radius: 18px;
+  border: 1px solid rgba(21, 41, 31, 0.12);
+  padding: 10px;
+  box-shadow: 0 16px 30px rgba(21, 41, 31, 0.14);
+}
+
+.management-visual img {
+  display: block;
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+  border-radius: 12px;
+  box-shadow: 0 14px 24px rgba(21, 41, 31, 0.18);
+}
+
+@media (max-width: 960px) {
+  .management-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .management-visual {
+    max-width: none;
+    justify-self: stretch;
+  }
+}


### PR DESCRIPTION
## Summary
- add visual treatment to the marketplace highlight using the new common area photography and green overlay
- create a management/automação two-column block pairing existing copy with the technology imagery
- apply a soft aerial background with overlays behind the metrics cards and centralize new styles for the home page

## Testing
- npm run lint *(fails: Missing script "lint")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923c29d2f488333a239e3f1b8403085)