### PR TITLE
Ajustar fundo do app-shell para respeitar tema

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,7 +2,6 @@ import { ProvedorContextoApp } from './contexts/AppContext';
 import { ProvedorPlanoContas } from './contexts/PlanoContasContext';
 import { ProvedorLancamentos } from './contexts/LancamentosContext';
 import { AplicativoCondominio } from './components/AplicativoCondominio';
-import { Toaster } from './components/ui/sonner';
 
 export default function App() {
   return (
@@ -11,7 +10,6 @@ export default function App() {
         <ProvedorLancamentos>
           <div className="size-full">
             <AplicativoCondominio />
-             <Toaster richColors position="top-center" />
           </div>
         </ProvedorLancamentos>
       </ProvedorPlanoContas>

--- a/components/AplicativoCondominio.tsx
+++ b/components/AplicativoCondominio.tsx
@@ -40,6 +40,7 @@ import { PaginaFaq } from './paginas/PaginaFaq';
 import { PaginaFaqSindico } from './paginas/PaginaFaqSindico';
 import { PaginaAssembleias } from './paginas/PaginaAssembleias';
 import { PaginaMarketplaceDetalhes } from "./paginas/PaginaMarketplaceDetalhes";
+import { AppLayout } from './layouts/AppLayout';
 
 
 
@@ -175,15 +176,21 @@ export function AplicativoCondominio() {
 
   if (estaCarregando) {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
-      </div>
+      <AppLayout>
+        <div className="flex min-h-screen items-center justify-center">
+          <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-primary"></div>
+        </div>
+      </AppLayout>
     );
   }
 
   if (!usuarioLogado) {
     if (publicPath === '/entrar') {
-      return <TelaLogin onVoltarInicio={() => navegarPublico('/')} />;
+      return (
+        <AppLayout>
+          <TelaLogin onVoltarInicio={() => navegarPublico('/')} />
+        </AppLayout>
+      );
     }
 
     const MarketingComponent = MARKETING_ROUTES[publicPath] ?? MARKETING_ROUTES['/'];
@@ -275,11 +282,13 @@ export function AplicativoCondominio() {
   };
 
   return (
-    <LayoutPrincipal 
-      paginaAtiva={paginaAtiva} 
-      onMudarPagina={setPaginaAtiva}
-    >
-      {renderizarPagina()}
-    </LayoutPrincipal>
+    <AppLayout>
+      <LayoutPrincipal
+        paginaAtiva={paginaAtiva}
+        onMudarPagina={setPaginaAtiva}
+      >
+        {renderizarPagina()}
+      </LayoutPrincipal>
+    </AppLayout>
   );
 }

--- a/components/layouts/AppLayout.tsx
+++ b/components/layouts/AppLayout.tsx
@@ -1,0 +1,26 @@
+import { ThemeProvider } from 'next-themes';
+import type { ReactNode } from 'react';
+import { Toaster } from '../ui/sonner';
+
+interface AppLayoutProps {
+  children: ReactNode;
+}
+
+// Layout que aplica o ThemeProvider apenas nas áreas autenticadas/"entrar"
+export function AppLayout({ children }: AppLayoutProps) {
+  return (
+    <ThemeProvider
+      attribute="class"
+      defaultTheme="light"
+      enableSystem
+      storageKey="meucondominio-theme"
+    >
+      <div className="app-shell min-h-screen bg-background text-foreground">
+        {children}
+        <Toaster richColors position="top-center" />
+      </div>
+    </ThemeProvider>
+  );
+}
+
+export default AppLayout;

--- a/components/marketing/MarketingLayout.tsx
+++ b/components/marketing/MarketingLayout.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState, type MouseEvent, type ReactNode } from 'react';
-import { useTheme } from 'next-themes';
 
 export type MarketingPath =
   | '/'
@@ -38,21 +37,6 @@ export function MarketingLayout({
 }: MarketingLayoutProps) {
   const [isScrolled, setIsScrolled] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const { setTheme, theme } = useTheme();
-
-  // Força tema claro na landing marketing e restaura o tema anterior ao desmontar
-  useEffect(() => {
-    const prev = theme;
-    // força light enquanto o layout de marketing estiver montado
-    setTheme('light');
-
-    return () => {
-      // restaura o tema anterior (pode ser undefined — next-themes tratará)
-      if (prev) setTheme(prev);
-    };
-    // observamos apenas setTheme e theme no mount
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const handleNavigate = (event: MouseEvent<HTMLAnchorElement>, path: MarketingPath) => {
     event.preventDefault();
@@ -161,17 +145,6 @@ export function MarketingLayout({
           background: #f4f5f3; /* Tom ainda claro quando a página rola */
           border-color: rgba(52, 78, 65, 0.16);
           box-shadow: 0 10px 20px rgba(21, 41, 31, 0.14);
-        }
-
-        :where(.dark) .marketing-header {
-          background: rgba(15, 23, 42, 0.85);
-          box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
-        }
-
-        :where(.dark) .marketing-header[data-scrolled='true'] {
-          background: rgba(15, 23, 42, 0.92);
-          border-color: rgba(148, 163, 184, 0.16);
-          box-shadow: 0 18px 45px rgba(0, 0, 0, 0.45);
         }
 
         .marketing-nav {
@@ -1078,11 +1051,6 @@ export function MarketingLayout({
             width: 100%;
           }
 
-          :where(.dark) .marketing-menu {
-            background: rgba(15, 23, 42, 0.95);
-            border-color: rgba(148, 163, 184, 0.2);
-            box-shadow: 0 24px 52px rgba(0, 0, 0, 0.4);
-          }
         }
 
         @media (max-width: 768px) {

--- a/main.tsx
+++ b/main.tsx
@@ -1,19 +1,11 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
-import { ThemeProvider } from 'next-themes';
 import './styles/globals.css';
 
 const container = document.getElementById('root')!;
 createRoot(container).render(
   <React.StrictMode>
-    <ThemeProvider 
-      attribute="class" 
-      defaultTheme="light" 
-      enableSystem 
-      storageKey="meucondominio-theme"
-    >
-      <App />
-    </ThemeProvider>
-  </React.StrictMode>
+    <App />
+  </React.StrictMode>,
 );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -140,7 +140,15 @@
   }
 
   body {
-    @apply bg-[color:var(--bg)] text-foreground antialiased;
+    @apply antialiased;
+    background-color: #020817; /* Landing permanece escura por padrão */
+    color: #e2e8f0;
+  }
+
+  /* Aplica tokens de tema apenas nas áreas autenticadas/"entrar" */
+  .app-shell {
+    /* Tokens de tema aplicados apenas para login/dashboard */
+    @apply bg-background text-foreground;
   }
 }
 


### PR DESCRIPTION
## Resumo
- aplica tokens de tema no `.app-shell` para que login e dashboard sigam o tema claro/escuro
- mantém a landing fora do escopo do ThemeProvider, preservando o visual fixo

## Testes
- não executado (não solicitado)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69249adfa2b88333a4be5e901efe93d7)