### PR TITLE
Revamp operations section on marketing home

### DIFF
--- a/components/marketing/HomePage.tsx
+++ b/components/marketing/HomePage.tsx
@@ -3,30 +3,13 @@ import Hero from '@/src/components/Hero';
 import '@/styles/marketing-home.css';
 import { MarketingLayout, type MarketingPageProps } from './MarketingLayout';
 import { SolutionsSection } from './SolutionsSection';
+import { OperationsSection } from './OperationsSection';
 
 const MARKETPLACE_CHIPS = [
   'Moradores vendem produtos e oferecem serviços',
   'Contratação de prestadores da comunidade',
   'Financeiro integrado e conciliado automaticamente',
   'Cupons e combos para fornecedores parceiros',
-];
-
-const OPERATIONS_FEATURES = [
-  {
-    title: 'Portaria digital e acesso seguro',
-    description: 'Controle visitantes, entregas e prestadores com QR Code, autorização instantânea e histórico centralizado.',
-    image: '/assets/marketing/portariadigital.png',
-  },
-  {
-    title: 'Comunidade conectada',
-    description: 'Engajamento com eventos, comunicados segmentados e serviços entre vizinhos para fortalecer o convívio.',
-    image: '/assets/marketing/pessoas.png',
-  },
-  {
-    title: 'Bem-estar e áreas comuns',
-    description: 'Reservas inteligentes de piscina, academia e salão de festas com regras claras e monitoramento.',
-    image: '/assets/marketing/piscina.png',
-  },
 ];
 
 const TESTIMONIALS = [
@@ -150,46 +133,7 @@ export function MarketingHomePage({ onNavigate, onLogin }: MarketingPageProps) {
         </div>
       </section>
 
-      <section className="bg-[#f9faf8] py-16" aria-labelledby="operacoes-heading">
-        <div className="marketing-container space-y-10">
-          <div className="flex flex-col gap-3">
-            <span className="marketing-badge w-fit" aria-hidden>
-              Segurança, comunidade e bem-estar
-            </span>
-            <h2 id="operacoes-heading" className="marketing-tagline text-3xl font-semibold text-[#15291f] sm:text-4xl">
-              Operações que conectam portaria, convivência e lazer.
-            </h2>
-            <p className="marketing-subtitle max-w-4xl text-lg text-[#344e41]">
-              Portaria digital com QR Code, controle de visitantes, reservas de áreas comuns e um feed para engajar moradores e colaboradores.
-            </p>
-          </div>
-
-          <div className="grid gap-6 md:grid-cols-3">
-            {OPERATIONS_FEATURES.map((feature) => (
-              <article
-                key={feature.title}
-                className="flex h-full flex-col overflow-hidden rounded-3xl bg-white shadow-[0_18px_32px_rgba(21,41,31,0.08)] ring-1 ring-[#dce3dc]"
-              >
-                <div className="aspect-[4/3] overflow-hidden">
-                  <img
-                    src={feature.image}
-                    alt={feature.title}
-                    className="h-full w-full object-cover"
-                    loading="lazy"
-                  />
-                </div>
-                <div className="flex flex-1 flex-col gap-3 p-6">
-                  <h3 className="text-xl font-semibold text-[#15291f]">{feature.title}</h3>
-                  <p className="text-sm leading-relaxed text-[#475e52]">{feature.description}</p>
-                  <div className="mt-auto inline-flex w-fit items-center gap-2 rounded-full bg-[#e8f0ea] px-4 py-2 text-xs font-semibold uppercase tracking-wide text-[#2f4b3d]">
-                    Proteção contínua
-                  </div>
-                </div>
-              </article>
-            ))}
-          </div>
-        </div>
-      </section>
+      <OperationsSection onNavigate={onNavigate} />
 
       <section className="py-16" aria-labelledby="gestao-tecnologia-heading">
         <div className="marketing-container grid gap-10 lg:grid-cols-[1.05fr_0.95fr] lg:items-center">

--- a/components/marketing/OperationsSection.tsx
+++ b/components/marketing/OperationsSection.tsx
@@ -1,0 +1,91 @@
+import type { MarketingPageProps } from './MarketingLayout';
+
+const OPERATIONS = [
+  {
+    title: 'Portaria digital e acesso seguro',
+    description: 'Controle de visitantes, entregas, registro de ocorrências e comunicação com portaria.',
+    image: '/assets/marketing/portariadigital.png',
+    badge: 'Portaria e segurança',
+    ctaLabel: 'Ver portaria em ação',
+    href: '/portaria',
+  },
+  {
+    title: 'Comunidade conectada',
+    description: 'Murais, avisos, enquetes e interação direta com moradores e equipes.',
+    image: '/assets/marketing/pessoas.png',
+    badge: 'Comunicação viva',
+    ctaLabel: 'Ver experiência do morador',
+    href: '/comunidade',
+  },
+  {
+    title: 'Bem-estar nas áreas comuns',
+    description: 'Reservas de salão, churrasqueira, academia e piscinas com regras claras e automações.',
+    image: '/assets/marketing/piscina.png',
+    badge: 'Áreas comuns e lazer',
+    ctaLabel: 'Ver gestão de reservas',
+    href: '/reservas',
+  },
+];
+
+type OperationsSectionProps = Pick<MarketingPageProps, 'onNavigate'>;
+
+export function OperationsSection({ onNavigate }: OperationsSectionProps) {
+  return (
+    <section className="bg-[#f9faf8] py-16" aria-labelledby="operacoes-heading">
+      <div className="marketing-container space-y-10">
+        <div className="flex flex-col gap-3">
+          <span className="marketing-badge w-fit" aria-hidden>
+            Segurança, comunidade e bem-estar
+          </span>
+          <h2 id="operacoes-heading" className="marketing-tagline text-3xl font-semibold text-[#15291f] sm:text-4xl">
+            Operações que conectam portaria, convivência e lazer.
+          </h2>
+          <p className="marketing-subtitle max-w-4xl text-lg text-[#344e41]">
+            Integre portaria, avisos, reservas e convivência em um painel que organiza a rotina e melhora a experiência de quem mora e trabalha no condomínio.
+          </p>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-3">
+          {OPERATIONS.map((feature) => (
+            <article
+              key={feature.title}
+              className="group flex h-full flex-col overflow-hidden rounded-3xl border border-[#d6dbd4] bg-white shadow-[0_18px_32px_rgba(21,41,31,0.08)] transition duration-200 hover:-translate-y-1 hover:border-[#2f4b3d] hover:shadow-[0_22px_40px_rgba(21,41,31,0.12)]"
+            >
+              {feature.image && (
+                <div className="relative aspect-[4/3] overflow-hidden bg-[#f4f7f3]">
+                  <img
+                    src={feature.image}
+                    alt={feature.title}
+                    className="h-full w-full object-cover transition duration-200 group-hover:scale-[1.01]"
+                    loading="lazy"
+                  />
+                </div>
+              )}
+
+              <div className="flex flex-1 flex-col gap-4 p-6">
+                <div className="inline-flex w-fit items-center gap-2 rounded-full bg-[#e8f0ea] px-3 py-1 text-xs font-semibold uppercase tracking-wide text-[#2f4b3d]">
+                  <span className="inline-block h-2 w-2 rounded-full bg-[#2f4b3d]" aria-hidden />
+                  {feature.badge}
+                </div>
+                <div className="space-y-2">
+                  <h3 className="text-xl font-semibold text-[#15291f]">{feature.title}</h3>
+                  <p className="text-sm leading-relaxed text-[#475e52]">{feature.description}</p>
+                </div>
+                {feature.ctaLabel && feature.href && (
+                  <button
+                    type="button"
+                    onClick={() => onNavigate(feature.href)}
+                    className="mt-auto inline-flex w-fit items-center gap-2 text-sm font-semibold text-[#2f4b3d] transition hover:text-[#1f3327] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#a3b18a] focus-visible:ring-offset-white"
+                  >
+                    {feature.ctaLabel}
+                    <span aria-hidden>→</span>
+                  </button>
+                )}
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- extracted the operations content into a dedicated OperationsSection component with updated messaging
- refreshed the three operations cards with imagery, category badges, and subtle hover/CTA interactions
- kept styling aligned with existing marketing palette and responsive grid behavior

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924bc52d1008333a175769dbacb3663)