### PR TITLE
Atualiza imagens da home marketing

### DIFF
--- a/components/marketing/DemoSection.tsx
+++ b/components/marketing/DemoSection.tsx
@@ -1,5 +1,7 @@
 import { PlayCircle } from 'lucide-react';
 
+import { demoPreview } from '@/src/assets/images';
+
 import type { MarketingPageProps } from './MarketingLayout';
 
 const DEMO_RESULTS = [
@@ -62,7 +64,7 @@ export function DemoSection({ onNavigate }: DemoSectionProps) {
           <div className="flex flex-col gap-4">
             <div className="relative overflow-hidden rounded-3xl border border-[#d6dbd4] bg-white shadow-[0_18px_36px_rgba(21,41,31,0.12)]">
               <img
-                src="/assets/marketing/hero-desktop.png"
+                src={demoPreview}
                 alt="Pré-visualização do painel do sistema Meu Condomínio"
                 className="h-full w-full object-cover"
                 loading="lazy"

--- a/components/marketing/HomePage.tsx
+++ b/components/marketing/HomePage.tsx
@@ -1,4 +1,6 @@
 import { useEffect } from 'react';
+
+import { marketplaceReceivables, professionalManager } from '@/src/assets/images';
 import Hero from '@/src/components/Hero';
 import '@/styles/marketing-home.css';
 import { MarketingLayout, type MarketingPageProps } from './MarketingLayout';
@@ -115,7 +117,7 @@ export function MarketingHomePage({ onNavigate, onLogin }: MarketingPageProps) {
                   </span>
                 </div>
                 <img
-                  src="/assets/marketing/notebookvendas.png"
+                  src={marketplaceReceivables}
                   alt="Notebook exibindo vendas do marketplace do condomínio"
                   className="mt-5 w-full rounded-2xl object-cover shadow-md aspect-[4/3]"
                   loading="lazy"
@@ -174,7 +176,7 @@ export function MarketingHomePage({ onNavigate, onLogin }: MarketingPageProps) {
           <div className="relative">
             <div className="absolute -left-6 -top-6 h-24 w-24 rounded-full bg-[#c7d9cf]/70 blur-3xl" aria-hidden />
             <img
-              src="/assets/marketing/gestao-tecnologia-condominio.png"
+              src={professionalManager}
               alt="Dashboard de gestão do condomínio em notebook"
               className="relative z-10 w-full rounded-3xl object-cover shadow-[0_22px_44px_rgba(21,41,31,0.15)] ring-1 ring-[#d6dbd4]"
               loading="lazy"

--- a/components/marketing/SolutionsSection.tsx
+++ b/components/marketing/SolutionsSection.tsx
@@ -1,5 +1,7 @@
 import { BarChart3, ClipboardList, ShieldCheck, ShoppingBag } from 'lucide-react';
 
+import { dashboardKpis, dailyOpsScreenshot, lobbyPhoto, marketplaceMobile } from '@/src/assets/images';
+
 import type { MarketingPageProps } from './MarketingLayout';
 
 const SOLUTIONS = [
@@ -8,15 +10,15 @@ const SOLUTIONS = [
     description:
       'Avisos segmentados, reservas de áreas comuns e registro de demandas em um painel que organiza a rotina do condomínio.',
     icon: ClipboardList,
-    image: '/assets/marketing/hero-desktop.png',
-    imageAlt: 'Notebook exibindo painel de gestão diária do condomínio',
+    image: dailyOpsScreenshot,
+    imageAlt: 'Painel principal do síndico com rotinas do condomínio',
   },
   {
     title: 'Marketplace para moradores',
     description:
       'Moradores compram produtos e serviços em um ambiente exclusivo do condomínio com pagamentos e histórico registrados.',
     icon: ShoppingBag,
-    image: '/assets/marketing/celularvendas.png',
+    image: marketplaceMobile,
     imageAlt: 'Aplicativo de marketplace do condomínio aberto em um celular',
   },
   {
@@ -24,7 +26,7 @@ const SOLUTIONS = [
     description:
       'Controle de acessos, visitantes e entregas com comunicação rápida com a portaria e histórico centralizado.',
     icon: ShieldCheck,
-    image: '/assets/marketing/portariadigital.png',
+    image: lobbyPhoto,
     imageAlt: 'Corredor moderno representando a portaria digital do condomínio',
   },
   {
@@ -32,8 +34,8 @@ const SOLUTIONS = [
     description:
       'Relatórios e visão financeira consolidados para síndicos e administradoras tomarem decisões com confiança.',
     icon: BarChart3,
-    image: '/assets/marketing/gestao-tecnologia-condominio.png',
-    imageAlt: 'Gestor analisando indicadores financeiros do condomínio em um notebook',
+    image: dashboardKpis,
+    imageAlt: 'Dashboard financeiro com indicadores e gráficos do condomínio',
   },
 ];
 
@@ -76,11 +78,11 @@ export function SolutionsSection({ onNavigate }: SolutionsSectionProps) {
               <p className="text-base leading-relaxed text-[#475e52]">{solution.description}</p>
 
               {solution.image && (
-                <div className="mt-2 aspect-[4/3] overflow-hidden rounded-2xl bg-[#f7f9f6]">
+                <div className="mt-4 overflow-hidden rounded-2xl bg-[#f7f9f6]">
                   <img
                     src={solution.image}
                     alt={solution.imageAlt}
-                    className="h-full w-full rounded-2xl object-cover transition duration-200 group-hover:scale-[1.01]"
+                    className="w-full h-64 object-cover transition duration-200 group-hover:scale-[1.01]"
                     loading="lazy"
                   />
                 </div>

--- a/src/assets/images.ts
+++ b/src/assets/images.ts
@@ -1,0 +1,8 @@
+export const heroBuilding = '/assets/marketing/fundo.png';
+export const dailyOpsScreenshot = '/assets/marketing/notebookinicial.png';
+export const marketplaceMobile = '/assets/marketing/celularvendas.png';
+export const lobbyPhoto = '/assets/marketing/portariadigital.png';
+export const dashboardKpis = '/assets/marketing/notebookvendas.png';
+export const professionalManager = '/assets/marketing/gestao-tecnologia-condominio.png';
+export const demoPreview = '/assets/marketing/landing.png';
+export const marketplaceReceivables = '/assets/marketing/vendas.png';

--- a/src/pages/HomeNew.tsx
+++ b/src/pages/HomeNew.tsx
@@ -11,6 +11,7 @@ import {
   Star,
   X,
 } from 'lucide-react';
+import { dashboardKpis, marketplaceReceivables } from '@/src/assets/images';
 import ThemeToggle from '../components/home/ThemeToggle';
 import { FinancialMarketplaceSection } from '../components/FinancialMarketplaceSection';
 import type { MarketingPageProps, MarketingPath } from '../../components/marketing/MarketingLayout';
@@ -1487,8 +1488,8 @@ export default function HomeNew({ onLogin, onNavigate }: MarketingPageProps) {
 
             <div className="home-revenue__media">
               <img
-                src="/assets/marketing/gestao-tecnologia-condominio.png"
-                alt="Síndico analisando vendas do marketplace no notebook"
+                src={dashboardKpis}
+                alt="Dashboard financeiro com indicadores do condomínio"
                 loading="lazy"
                 decoding="async"
               />
@@ -1496,7 +1497,7 @@ export default function HomeNew({ onLogin, onNavigate }: MarketingPageProps) {
 
             <div className="home-revenue__media">
               <img
-                src="/assets/marketing/vendas.png"
+                src={marketplaceReceivables}
                 alt="Aplicativo do marketplace exibindo compras no celular"
                 loading="lazy"
                 decoding="async"


### PR DESCRIPTION
## Summary
- centralize marketing image paths and align home sections with dedicated assets
- update solution cards, demo preview, and professional management section to avoid image repetition
- refine marketplace receivables card to usar um asset dedicado de receitas

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924f480cefc8333b53d14a27d994447)