### PR TITLE
Refine marketing home UX

### DIFF
--- a/components/marketing/DemoSection.tsx
+++ b/components/marketing/DemoSection.tsx
@@ -1,5 +1,3 @@
-import { PlayCircle } from 'lucide-react';
-
 import { demoPreview } from '@/src/assets/images';
 
 import type { MarketingPageProps } from './MarketingLayout';
@@ -30,64 +28,54 @@ export function DemoSection({ onNavigate }: DemoSectionProps) {
             </span>
             <div className="space-y-3">
               <h2 id="demo-heading" className="marketing-tagline text-3xl font-semibold text-[#15291f] sm:text-4xl">
-                Veja o sistema na prática em menos de 3 minutos.
+                Veja o sistema na prática antes de contratar.
               </h2>
               <p className="marketing-subtitle text-lg text-[#344e41]">
-                Conheça as telas principais do painel do síndico, do morador e da administradora em uma demonstração rápida que mostra o fluxo real de uso no dia a dia.
+                Demonstração guiada e online mostrando como síndicos, administradoras e condomínios usam o painel no dia a dia — sem precisar assistir a vídeo gravado.
               </p>
             </div>
 
-            <div className="flex flex-wrap gap-4">
-              <a
-                href="/demo"
-                onClick={(event) => {
-                  event.preventDefault();
-                  onNavigate('/demo');
-                }}
-                className="inline-flex items-center justify-center rounded-full bg-[#344e41] px-6 py-3 text-sm font-semibold text-white shadow-lg transition hover:-translate-y-0.5 hover:bg-[#2a3d33] focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-[#a3b18a]"
-              >
-                Assistir demonstração agora
-              </a>
+            <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:gap-4">
               <a
                 href="/comece"
                 onClick={(event) => {
                   event.preventDefault();
                   onNavigate('/comece');
                 }}
-                className="inline-flex items-center justify-center rounded-full bg-white px-5 py-3 text-sm font-semibold text-[#15291f] shadow-md ring-1 ring-[#d6dbd4] transition hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-[#a3b18a]"
+                className="inline-flex items-center justify-center rounded-full bg-[#344e41] px-6 py-3 text-sm font-semibold text-white shadow-lg transition hover:-translate-y-0.5 hover:bg-[#2a3d33] focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-[#a3b18a]"
               >
-                Agendar demonstração guiada com um especialista
+                Agendar demonstração
+              </a>
+              <a
+                href="/demo"
+                onClick={(event) => {
+                  event.preventDefault();
+                  onNavigate('/demo');
+                }}
+                className="inline-flex items-center justify-center rounded-full bg-white px-5 py-3 text-sm font-semibold text-[#15291f] shadow-md ring-1 ring-[#d6dbd4] transition hover:-translate-y-0.5 hover:bg-[#f7f9f6] hover:shadow-lg focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-[#a3b18a]"
+              >
+                Ver o sistema na prática
               </a>
             </div>
+
+            <p className="text-sm font-medium text-[#3f5b4c]">Demonstração online, sem compromisso.</p>
           </div>
 
           <div className="flex flex-col gap-4">
-            <div className="relative overflow-hidden rounded-3xl border border-[#d6dbd4] bg-white shadow-[0_18px_36px_rgba(21,41,31,0.12)]">
+            <div className="overflow-hidden rounded-3xl border border-[#d6dbd4] bg-white/85 shadow-xl ring-1 ring-[#d6dbd4]">
               <img
                 src={demoPreview}
-                alt="Pré-visualização do painel do sistema Meu Condomínio"
-                className="h-full w-full object-cover"
+                alt="Painel do sistema Meu Condomínio com indicadores e ações"
+                className="h-64 w-full object-cover"
                 loading="lazy"
               />
-              {/* Substitua este overlay por um player de vídeo real quando disponível */}
-              <button
-                type="button"
-                onClick={() => onNavigate('/demo')}
-                className="absolute inset-0 flex items-center justify-center bg-[#15291f]/30 transition hover:bg-[#15291f]/40 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-white/60"
-                aria-label="Assistir demonstração em vídeo"
-              >
-                <span className="inline-flex items-center gap-2 rounded-full bg-white/95 px-5 py-3 text-[#15291f] shadow-lg ring-1 ring-[#d6dbd4]">
-                  <PlayCircle className="h-6 w-6" aria-hidden />
-                  <span className="text-sm font-semibold">Dar o play</span>
-                </span>
-              </button>
             </div>
 
             <div className="grid gap-3 sm:grid-cols-2">
               {DEMO_RESULTS.map((result) => (
                 <article
                   key={result.label}
-                  className="rounded-2xl bg-white p-4 shadow-md ring-1 ring-[#dce3dc]"
+                  className="flex h-full flex-col justify-between rounded-2xl bg-white p-4 shadow-md ring-1 ring-[#dce3dc]"
                 >
                   <p className="text-sm font-semibold text-[#2f4b3d]">{result.label}</p>
                   <p className="text-2xl font-bold text-[#2f4b3d]">{result.value}</p>

--- a/components/marketing/MarketingLayout.tsx
+++ b/components/marketing/MarketingLayout.tsx
@@ -137,7 +137,7 @@ export function MarketingLayout({
           background: #E9E9E9; /* Header claro com logo em destaque (paleta) */
           border-bottom: 1px solid rgba(52, 78, 65, 0.08);
           box-shadow: 0 6px 14px rgba(21, 41, 31, 0.08);
-          padding: 18px 0; /* Mais respiro no topo seguindo o branding */
+          padding: 12px 0; /* Altura leve mantendo o foco no hero */
           transition: background 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
         }
 
@@ -150,8 +150,8 @@ export function MarketingLayout({
         .marketing-nav {
           display: flex;
           align-items: center;
-          gap: 16px;
-          min-height: 72px;
+          gap: 18px;
+          min-height: 64px;
           position: relative;
           font-family: 'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
         }
@@ -203,18 +203,18 @@ export function MarketingLayout({
         .marketing-menu {
           display: flex;
           align-items: center;
-          gap: 16px;
+          gap: 18px;
           margin-left: auto;
         }
 
         .marketing-menu__links {
           display: flex;
           align-items: center;
-          gap: 12px;
+          gap: 20px;
         }
 
         .marketing-menu a {
-          padding: 9px 13px;
+          padding: 9px 14px;
           border-radius: 12px;
           color: #15291f; /* Navegação em tom escuro da paleta */
           transition: transform 0.15s, background 0.15s, color 0.15s;
@@ -237,7 +237,7 @@ export function MarketingLayout({
 
         .marketing-actions {
           display: flex;
-          gap: 10px;
+          gap: 12px;
           align-items: center;
         }
 
@@ -998,6 +998,16 @@ export function MarketingLayout({
           color: var(--brand);
         }
 
+        @media (min-width: 1024px) {
+          .marketing-header {
+            padding: 16px 0;
+          }
+
+          .marketing-nav {
+            min-height: 72px;
+          }
+        }
+
         @media (max-width: 960px) {
           .marketing-nav {
             height: auto;
@@ -1109,11 +1119,11 @@ export function MarketingLayout({
               <div className="marketing-actions">
                 <a
                   href="/comece"
-                  className="marketing-cta"
-                  onClick={handlePrimaryCta}
-                >
-                  Começar agora
-                </a>
+          className="marketing-cta"
+          onClick={handlePrimaryCta}
+        >
+          Agendar demonstração
+        </a>
 
                 <a
                   href="/entrar"

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -49,10 +49,10 @@ export default function Hero({ onPrimaryClick, onSecondaryClick }: HeroProps) {
                 id="hero-heading"
                 className="hero-headline text-3xl font-bold leading-tight tracking-tight text-white sm:text-4xl lg:text-5xl"
               >
-                Gestão completa e marketplace em um único painel para o seu condomínio
+                Software de gestão condominial com marketplace integrado.
               </h1>
               <p className="max-w-3xl text-lg font-medium text-white/90">
-                Centralize comunicação, pagamentos, portaria e compras em uma plataforma pensada para síndicos, administradoras e moradores.
+                Comunicação, financeiro, portaria e compras em um painel único, feito sob medida para síndicos profissionais, administradoras e condomínios modernos.
               </p>
             </div>
             <div className="flex flex-wrap gap-3 text-sm font-semibold text-white/85">
@@ -89,7 +89,6 @@ export default function Hero({ onPrimaryClick, onSecondaryClick }: HeroProps) {
               }}
               className="inline-flex w-full items-center justify-center gap-2 rounded-full border border-white/60 bg-white/5 px-7 py-3 text-base font-semibold text-white shadow-md transition duration-200 hover:translate-y-[1px] hover:border-white hover:bg-white/10 hover:shadow-lg focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-white/60 sm:w-auto sm:min-w-[220px]"
             >
-              <span aria-hidden className="flex h-8 w-8 items-center justify-center rounded-full bg-white/10 text-sm font-bold">▶</span>
               <span>Ver o sistema na prática</span>
             </button>
           </div>


### PR DESCRIPTION
## Summary
- Adjust sticky header padding and navigation gaps to keep the marketing navbar light while retaining CTA prominence
- Reflow the demo CTA stack with clearer microcopy and improved hover/focus treatments for the secondary action
- Soften the demo preview card styling and balance metrics tiles for consistent heights

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924f7a8ced8833393ef41d76f402984)